### PR TITLE
feat(ci): add SLSA L1 provenance attestation (OWASP A03)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,6 +9,10 @@ on:
     # Run tests daily at 2 AM UTC
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+  actions: read
+
 env:
   PYTHON_VERSION: "3.12"
   POETRY_VERSION: "1.7.1"
@@ -540,7 +544,7 @@ jobs:
       - name: Upload package
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
-          name: package
+          name: dist
           path: dist/
 
   # =============================================================================

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -18,7 +18,6 @@ jobs:
   provenance:
     name: Generate Provenance Attestation
     runs-on: ubuntu-latest
-    needs: [ci-cd]
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -1,0 +1,42 @@
+# =============================================================================
+# SLSA L1 — Provenance Attestation (OWASP A03: Supply Chain)
+# Generates signed provenance for build artifacts
+# =============================================================================
+
+name: SLSA Provenance Attestation
+
+on:
+  push:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+  id-token: write   # Required for OIDC signing
+  attestations: write
+
+jobs:
+  provenance:
+    name: Generate Provenance Attestation
+    runs-on: ubuntu-latest
+    needs: [ci-cd]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: dist/*
+
+      - name: Upload provenance artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: provenance
+          path: .attestation/
+          retention-days: 90

--- a/.github/workflows/verify-provenance.yml
+++ b/.github/workflows/verify-provenance.yml
@@ -1,0 +1,32 @@
+# =============================================================================
+# SLSA L1 — Verify Provenance Attestation (OWASP A03: Supply Chain)
+# Verifies that build artifacts have valid provenance
+# =============================================================================
+
+name: Verify Provenance
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+  attestations: read
+  id-token: write
+
+jobs:
+  verify:
+    name: Verify Source Provenance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Verify attestation
+        run: |
+          # List attestations for this commit
+          gh attestation verify "${{ github.sha }}" \
+            --owner ${{ github.repository_owner }} \
+            --predicate-type https://slsa.dev/provenance/v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Qué
- Add SLSA L1 provenance attestation workflow for build artifacts
- Add verification workflow for PRs
- Rename artifact for consistency

## Por qué
OWASP 2025 A03: Supply Chain Failures requires verifiable provenance. SLSA L1 ensures build artifacts have signed provenance attestations.

## Changes
- **provenance.yml**: Attests build artifacts using actions/attest-build-provenance@v2
- **verify-provenance.yml**: Verifies attestations on PRs
- **ci-cd.yml**: Renamed artifact 'package' → 'dist' for consistency

## Tests
- Workflow syntax validated
- Provenance attestation will generate on next push to main/develop

## Edge Cases
- Requires id-token: write permission for OIDC signing
- Provenance artifacts retained for 90 days