### PR TITLE
chore(deps): npm v12 install-scripts hardening — allowScripts esbuild + strict-allow-scripts CI/Docker + smoke post-install

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -265,12 +265,17 @@ jobs:
       - name: Set up Node.js for Playwright TypeScript tests
         uses: actions/setup-node@v4 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '26'
 
       - name: Install frontend dependencies
         run: |
           cd dashboard/frontend
-          npm ci
+          npm ci --strict-allow-scripts
+
+      - name: Smoke test post-install (npm v12 install-scripts)
+        run: |
+          cd dashboard/frontend
+          node scripts/smoke-install.mjs
 
       - name: Install Playwright browsers
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,13 +22,17 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '26'
           cache: 'npm'
           cache-dependency-path: dashboard/frontend/package-lock.json
 
       - name: Install dependencies
         working-directory: dashboard/frontend
-        run: npm ci
+        run: npm ci --strict-allow-scripts
+
+      - name: Smoke test post-install (npm v12 install-scripts)
+        working-directory: dashboard/frontend
+        run: node scripts/smoke-install.mjs
 
       - name: Install Playwright browsers
         working-directory: dashboard/frontend

--- a/.github/workflows/pr-deploy-coolify.yml
+++ b/.github/workflows/pr-deploy-coolify.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  NODE_VERSION: "18"
+  NODE_VERSION: "26"
 
 jobs:
   # Deploy Backend PR Preview
@@ -144,7 +144,12 @@ jobs:
       - name: Install Frontend Dependencies
         run: |
           cd dashboard/frontend
-          npm ci
+          npm ci --strict-allow-scripts
+
+      - name: Smoke test post-install (npm v12 install-scripts)
+        run: |
+          cd dashboard/frontend
+          node scripts/smoke-install.mjs
 
       - name: Build Frontend
         run: |

--- a/dashboard/frontend/Dockerfile
+++ b/dashboard/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:26-alpine
 
 WORKDIR /app
 
@@ -13,7 +13,12 @@ USER appuser
 COPY --chown=appuser:appgroup package*.json ./
 
 # Install dependencies
-RUN npm install
+# npm 12: enforce del allowlist de install scripts (allowScripts en package.json)
+RUN npm install --strict-allow-scripts
+
+# Smoke post-install: fallar el build si el binario nativo no carga
+COPY --chown=appuser:appgroup scripts/smoke-install.mjs ./scripts/smoke-install.mjs
+RUN node scripts/smoke-install.mjs
 
 # Copy the rest of the application
 COPY --chown=appuser:appgroup . .

--- a/dashboard/frontend/Dockerfile.prod
+++ b/dashboard/frontend/Dockerfile.prod
@@ -1,6 +1,6 @@
 # QA-FRAMEWORK Frontend - Production Dockerfile (Coolify)
 # Multi-stage build optimized for Coolify with base_directory: "/"
-FROM node:18-alpine AS builder
+FROM node:26-alpine AS builder
 
 WORKDIR /app
 
@@ -8,7 +8,13 @@ WORKDIR /app
 COPY dashboard/frontend/package*.json ./
 
 # Install ALL dependencies (including devDependencies for build)
-RUN npm ci
+# npm 12: enforce del allowlist de install scripts (allowScripts en package.json)
+RUN npm ci --strict-allow-scripts
+
+# Smoke post-install: fallar el build si el binario nativo no carga
+# (npm 12 bloquea scripts por defecto con exit 0 silencioso)
+COPY dashboard/frontend/scripts/smoke-install.mjs ./scripts/smoke-install.mjs
+RUN node scripts/smoke-install.mjs
 
 # Copy source code
 COPY dashboard/frontend/ ./
@@ -23,12 +29,13 @@ RUN npm run build
 # Production stage
 FROM node:18-alpine
 
+WORKDIR /app
+
 # Create non-root user for security (F-002 FIX)
+# WORKDIR antes del chown: /app debe existir (bug preexistente, fix card 0c00d7eb)
 RUN addgroup -g 1001 -S appuser && \
     adduser -S -D -H -u 1001 -s /sbin/nologin -G appuser appuser && \
-    chown -R appuser:appuser /app
-
-WORKDIR /app
+    chown appuser:appuser /app
 
 # Install serve for production
 RUN npm install -g serve

--- a/dashboard/frontend/package.json
+++ b/dashboard/frontend/package.json
@@ -50,5 +50,8 @@
     "typescript": "^5.2.2",
     "vite": "^5.0.0",
     "vitest": "^0.34.6"
+  },
+  "allowScripts": {
+    "esbuild@0.21.5": true
   }
 }

--- a/dashboard/frontend/scripts/smoke-install.mjs
+++ b/dashboard/frontend/scripts/smoke-install.mjs
@@ -1,0 +1,43 @@
+// npm v12 install-scripts smoke test (card 0c00d7eb)
+//
+// npm 12 bloquea los install scripts de dependencias por defecto y reporta
+// exit 0 silencioso: si el binario nativo de esbuild no llegó por optional
+// platform deps NI por postinstall aprobado, el fallo aparece en runtime.
+// Este smoke corre post-install en CI/Docker y FALLA el build si esbuild o
+// vite no cargan, cerrando el camino del silent-failure.
+//
+// Uso: node scripts/smoke-install.mjs   (tras npm ci / npm install)
+
+const failures = [];
+
+// --- esbuild: cargar módulo + invocar el binario nativo de verdad ---
+// import() puede resolver el JS aunque el binario falte; transformSync()
+// solo funciona si el binario nativo existe y ejecuta.
+try {
+  const esbuild = await import('esbuild');
+  const out = esbuild.transformSync('const answer = 6 * 7;', { loader: 'js' });
+  if (!out.code || !out.code.includes('answer')) {
+    throw new Error(`salida inesperada de transformSync: ${JSON.stringify(out.code)}`);
+  }
+  console.log(`[smoke] esbuild OK — binario nativo responde (${out.code.trim().length} bytes)`);
+} catch (err) {
+  failures.push(`esbuild: ${err.message}`);
+}
+
+// --- vite: carga del módulo (v5 es ESM-only, no require()) ---
+try {
+  const vite = await import('vite');
+  const version = vite.version ?? 'unknown';
+  console.log(`[smoke] vite OK — módulo carga (v${version})`);
+} catch (err) {
+  failures.push(`vite: ${err.message}`);
+}
+
+if (failures.length > 0) {
+  console.error('[smoke] FALLO post-install — módulos no operativos:');
+  for (const f of failures) console.error(`  - ${f}`);
+  console.error('[smoke] Causa probable: install script bloqueado por npm v12 sin allowScripts aprobado.');
+  process.exit(1);
+}
+
+console.log('[smoke] SMOKE-OK: esbuild + vite operativos post-install');


### PR DESCRIPTION
## What & Why

npm v12 (GA 2026-07) bloquea los install scripts de dependencias **por defecto con exit 0 silencioso**: un rebuild limpio con builder node≥26 instala "success" mientras el postinstall de esbuild nunca corrió. Este PR cierra ese hueco en el frontend del dashboard: trust explícito (allowScripts), enforcement en CI/Docker (`--strict-allow-scripts`) y smoke post-install que hace fallar el build si el binario nativo no carga.

Workboard: **0c00d7eb** (follow-up e977df1d — piloto E2E). Doc interna: `workspace-devops/docs/npm-v12-install-scripts-migration.md` §3-5.

## Changes

| File | Change |
|------|--------|
| `dashboard/frontend/package.json` | `allowScripts: {"esbuild@0.21.5": true}` — generado con `npm install-scripts approve esbuild` (version-pinned: upgrade ⇒ re-aprobar = señal anti supply-chain) |
| `dashboard/frontend/scripts/smoke-install.mjs` | NUEVO — smoke post-install: carga esbuild + invoca `transformSync` (binario nativo real) + importa vite (ESM-only, por eso `import()` y no `require()`); exit 1 si algo no carga |
| `dashboard/frontend/Dockerfile.prod` | builder node:18→26-alpine (npm 12), `npm ci --strict-allow-scripts`, smoke layer post-install. **+fix bug preexistente:** stage prod hacía `chown -R /app` ANTES de `WORKDIR /app` → `chown: /app: No such file or directory` — build ROTO en `main` desde el commit F-002 (verificado: `docker build` del Dockerfile de main falla igual). Reordenado WORKDIR + chown sin `-R` |
| `dashboard/frontend/Dockerfile` | node:18→26-alpine, `npm install --strict-allow-scripts`, smoke layer (este Dockerfile lo usa el PR-preview de Coolify) |
| `.github/workflows/ci-cd.yml` | job E2E: node 20→26, `npm ci --strict-allow-scripts`, step smoke |
| `.github/workflows/e2e.yml` | node 20→26, `npm ci --strict-allow-scripts`, step smoke |
| `.github/workflows/pr-deploy-coolify.yml` | NODE_VERSION 18→26, `npm ci --strict-allow-scripts`, step smoke pre-build |

**Por qué node 26:** `--strict-allow-scripts` solo existe en npm 12 (bundled con node 26); en npm 9/10 (node 18/20) es unknown option y el CI fallaría. jokerserver ya corre node 26.7.0 / npm 12.0.2.

## Evidence (verificado en jokerserver, npm 12.0.2 real)

- ✅ AC1 `allowScripts` commiteado (CLI-generated, no hand-edited)
- ✅ Negativo (HOME aislado, sin allowScripts): `npm ci --strict-allow-scripts` → **exit 1** `ESTRICTALLOWSCRIPTS: esbuild@0.21.5 (install scripts present)` — el enforcement es real. Nota: localmente `~/.npmrc` global con `ignore-scripts=true` ENMASCARA strict (por eso los tests usan HOME limpio, igual que CI/Docker)
- ✅ Positivo (HOME aislado, con allowScripts): strict ci exit 0 + smoke OK (`esbuild OK — binario nativo responde`, `vite OK v5.4.21`)
- ✅ AC4 `docker build` **Dockerfile.prod exit 0** (context raíz, como Coolify): strict ci → smoke dentro del builder → vite build `✓ built in 10.97s` → imagen exportada
- ✅ AC4 `docker build` **Dockerfile exit 0** (context frontend, como pr-deploy-coolify): strict install → smoke OK
- ✅ YAMLs de los 3 workflows validados (PyYAML safe_load)

## Test Plan (re-verificable)

```bash
git clone --branch chore/npm12-allow-scripts <repo> qa-fw-npm12 && cd qa-fw-npm12
# 1) enforcement falla sin allowScripts:
cd dashboard/frontend && node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));delete p.allowScripts;fs.writeFileSync('package.json',JSON.stringify(p,null,2))" && HOME=/tmp/cleanhome npm ci --strict-allow-scripts   # espera exit 1 ESTRICTALLOWSCRIPTS
git checkout -- package.json
# 2) pasa con allowScripts + smoke:
HOME=/tmp/cleanhome npm ci --strict-allow-scripts && node scripts/smoke-install.mjs   # espera SMOKE-OK
# 3) builds Docker:
cd .. && cd .. && docker build -f dashboard/frontend/Dockerfile.prod -t qa12:prod .   # espera exit 0
cd dashboard/frontend && docker build -t qa12:dev .                                    # espera exit 0
```

## Notas / Rollback

- `fsevents` (macOS-only) no requiere aprobación en builds Linux (npm no flaggea optionals no instalables en la plataforma).
- Devs en macOS: `npm install-scripts ls` les mostrará fsevents pendiente; aprobar solo si usan Mac localmente.
- Rollback: revert del commit restaura comportamiento anterior (npm 12 seguiría bloqueando scripts silenciosamente — el flag solo añade enforcement; no hay cambio de runtime de la app).
- Observación (fuera de scope): `dashboard/frontend` no tiene `.dockerignore` — el contexto de build dev arrastra `node_modules` si existe localmente (build lento). Candidato a chore posterior.