### PR TITLE
feat(qa-visual): Fase C wiring + auth + upload hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ docs/_build/
 # Playwright
 test-results/
 playwright-report/
+
+# QA Visual runtime artifacts (reports + hook screenshots)
+reports/qa-visual/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **QA Visual dashboard wiring (Fase C)**: the dashboard backend mounts the
   qa-visual router behind JWT auth (`Depends(get_current_user)`) — all five
-  endpoints require authentication. The module is vendored at
+  endpoints require authentication — **gated behind `QA_VISUAL_ENABLED=1`
+  (default off: the router is not mounted and endpoints return 404 until the
+  flag is set; report storage is not yet owner-scoped in the multi-tenant
+  dashboard)**. The module is vendored at
   `dashboard/backend/src/infrastructure/qa_visual/` (Docker build context only
   ships `dashboard/backend`), guarded by a vendor-parity test that fails on
   drift between the two copies.
@@ -28,8 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **S-3 (LOW)**: 502 responses no longer leak upstream gateway bodies or raw
   model output excerpts to HTTP clients (CWE-209); full detail is logged
   server-side only.
-- **S-5 (LOW)**: `target` form field capped at 255 chars (422 instead of an
-  uncontrolled OSError 500 on >255-byte filenames).
+- **S-5 (LOW)**: `target` form field capped at 200 chars (422; 200 + the
+  29-byte filename suffix stays under the 255-byte filesystem NAME_MAX,
+  avoiding the uncontrolled OSError 500 that 227–255-char targets triggered).
 - **S-7 (INFO)**: `reports/qa-visual/` runtime artifacts gitignored.
 - **S-4 (LOW)**: data-handling policy documented in `docs/qa-visual.md`
   (screenshots egress to the external vision gateway; synthetic/test data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **QA Visual dashboard wiring (Fase C)**: the dashboard backend mounts the
+  qa-visual router behind JWT auth (`Depends(get_current_user)`) — all five
+  endpoints require authentication. The module is vendored at
+  `dashboard/backend/src/infrastructure/qa_visual/` (Docker build context only
+  ships `dashboard/backend`), guarded by a vendor-parity test that fails on
+  drift between the two copies.
+
+### Security
+
+- **S-1 (HIGH)**: router factory now accepts injectable `dependencies`;
+  mounted in the dashboard with auth. Backward compatible (no dependencies
+  by default).
+- **S-2 (MEDIUM)**: upload hardening in `POST /analyze` — `Content-Length`
+  pre-check before reading, chunked read capped at 10 MB (never loads an
+  oversized file fully into memory), `image/png` content-type plus PNG
+  magic-byte validation (415, no paid API calls on junk uploads).
+- **S-3 (LOW)**: 502 responses no longer leak upstream gateway bodies or raw
+  model output excerpts to HTTP clients (CWE-209); full detail is logged
+  server-side only.
+- **S-5 (LOW)**: `target` form field capped at 255 chars (422 instead of an
+  uncontrolled OSError 500 on >255-byte filenames).
+- **S-7 (INFO)**: `reports/qa-visual/` runtime artifacts gitignored.
+- **S-4 (LOW)**: data-handling policy documented in `docs/qa-visual.md`
+  (screenshots egress to the external vision gateway; synthetic/test data
+  only; GDPR Art. 32 note).
+
 ## [1.1.0] - 2026-08-22
 
 ### Added

--- a/dashboard/backend/main.py
+++ b/dashboard/backend/main.py
@@ -11,6 +11,7 @@ from api.v1 import router as api_router
 from api.v1.health import router as health_router, set_startup_complete
 from api.v1.integrations import include_router as include_integrations_router
 from services.auth_service import get_current_user
+from src.infrastructure.qa_visual import create_qa_visual_router
 from core.logging_config import configure_logging, get_logger
 from models import User
 from integration.qa_framework_client import get_qa_test_suites
@@ -65,6 +66,11 @@ app.include_router(health_router, prefix="/api/v1")
 # Include integration router
 include_integrations_router(app)
 
+# QA Visual router (Fase C) — vendored copy under dashboard/backend/src,
+# mounted behind the dashboard auth (S-1): every endpoint requires a valid
+# JWT via Depends(get_current_user).
+app.include_router(create_qa_visual_router(dependencies=[Depends(get_current_user)]))
+
 # Add Prometheus metrics endpoint
 metrics_app = make_asgi_app()
 app.mount("/metrics", metrics_app)
@@ -76,13 +82,10 @@ async def startup_event():
     logger.info("Initializing QA-Framework Dashboard...")
     await init_db()
     set_startup_complete()
-    
+
     # Initialize APM
-    init_app_info(
-        version="0.1.0",
-        environment=settings.ENVIRONMENT
-    )
-    
+    init_app_info(version="0.1.0", environment=settings.ENVIRONMENT)
+
     logger.info("QA-Framework Dashboard initialized successfully")
 
 
@@ -109,13 +112,12 @@ async def get_qa_framework_suites(current_user: User = Depends(get_current_user)
         return {"suites": suites}
     except Exception as e:
         logger.error(f"Error getting QA-FRAMEWORK suites: {e}")
-        raise HTTPException(
-            status_code=500, detail=f"Error connecting to QA-FRAMEWORK: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Error connecting to QA-FRAMEWORK: {str(e)}")
 
 
 # Only run uvicorn directly when executed as script, not when imported
 if __name__ == "__main__":
     import os
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8000")))

--- a/dashboard/backend/main.py
+++ b/dashboard/backend/main.py
@@ -69,7 +69,12 @@ include_integrations_router(app)
 # QA Visual router (Fase C) — vendored copy under dashboard/backend/src,
 # mounted behind the dashboard auth (S-1): every endpoint requires a valid
 # JWT via Depends(get_current_user).
-app.include_router(create_qa_visual_router(dependencies=[Depends(get_current_user)]))
+# S-1R: the backend is multi-tenant without roles and the report store is
+# global (cross-tenant BOLA, CVSS 5.4), so the router stays UNMOUNTED
+# (endpoints 404) unless the deploy explicitly opts in with
+# QA_VISUAL_ENABLED=1, pending owner-scoped reports / role checks.
+if os.getenv("QA_VISUAL_ENABLED") == "1":
+    app.include_router(create_qa_visual_router(dependencies=[Depends(get_current_user)]))
 
 # Add Prometheus metrics endpoint
 metrics_app = make_asgi_app()

--- a/dashboard/backend/src/infrastructure/qa_visual/__init__.py
+++ b/dashboard/backend/src/infrastructure/qa_visual/__init__.py
@@ -1,0 +1,70 @@
+"""QA Visual module — vision-model screenshot analysis for the QA framework.
+
+Validated in Fase A (score 95/100, $0.000428/screenshot, 4.37s latency,
+0 hallucinations) and productized here per the GO-NOGO Fase B decision.
+
+Quick start:
+    from fastapi import FastAPI
+    from src.infrastructure.qa_visual import create_qa_visual_router
+
+    app = FastAPI()
+    app.include_router(create_qa_visual_router())  # config from env
+
+Spike conditions C1-C5 are enforced in config/gateway_client:
+thinking disabled, max_tokens >= 4000 when thinking on, browser UA,
+model id via env (QA_VISUAL_MODEL), pricing pinned 2026-08-22.
+"""
+
+from src.infrastructure.qa_visual.analyzer import (
+    QAVisualAnalysisError,
+    QAVisualAnalyzer,
+    build_trend_report,
+)
+from src.infrastructure.qa_visual.config import QAVisualConfig
+from src.infrastructure.qa_visual.endpoint import create_qa_visual_router
+from src.infrastructure.qa_visual.gateway_client import (
+    VisionGatewayClient,
+    VisionGatewayError,
+    VisionResult,
+)
+from src.infrastructure.qa_visual.models import (
+    Accessibility,
+    AnalyzeResponse,
+    IssueCategory,
+    LayoutInfo,
+    QAIssue,
+    QAAnalysis,
+    Severity,
+    TrendAlert,
+    TrendPoint,
+    VisualRegression,
+)
+from src.infrastructure.qa_visual.parser import ParseResult, parse_qa_analysis
+from src.infrastructure.qa_visual.playwright_hook import QAVisualHook
+from src.infrastructure.qa_visual.storage import QAVisualReportStore, new_report_id
+
+__all__ = [
+    "QAVisualConfig",
+    "QAVisualAnalyzer",
+    "QAVisualAnalysisError",
+    "QAVisualReportStore",
+    "QAVisualHook",
+    "VisionGatewayClient",
+    "VisionGatewayError",
+    "VisionResult",
+    "create_qa_visual_router",
+    "build_trend_report",
+    "parse_qa_analysis",
+    "ParseResult",
+    "new_report_id",
+    "QAAnalysis",
+    "QAIssue",
+    "Accessibility",
+    "LayoutInfo",
+    "VisualRegression",
+    "AnalyzeResponse",
+    "TrendPoint",
+    "TrendAlert",
+    "Severity",
+    "IssueCategory",
+]

--- a/dashboard/backend/src/infrastructure/qa_visual/analyzer.py
+++ b/dashboard/backend/src/infrastructure/qa_visual/analyzer.py
@@ -1,0 +1,160 @@
+"""Orchestrates the QA Visual pipeline: gateway -> parse -> threshold -> store.
+
+The analyzer owns two policy decisions from the GO-NOGO Fase B scope:
+- Threshold: ``score < threshold`` marks the report as failed.
+- Baseline regression: compares against the earliest report of the target;
+  a drop of ``degradation_alert_points`` or any visual_regression flag marks
+  the report as a regression.
+"""
+
+import logging
+from typing import List, Optional, Tuple
+
+from src.infrastructure.qa_visual.config import QAVisualConfig
+from src.infrastructure.qa_visual.gateway_client import (
+    VisionGatewayClient,
+    VisionGatewayError,
+)
+from src.infrastructure.qa_visual.models import AnalyzeResponse, TrendAlert, TrendPoint
+from src.infrastructure.qa_visual.parser import parse_qa_analysis
+from src.infrastructure.qa_visual.storage import QAVisualReportStore, new_report_id
+
+logger = logging.getLogger(__name__)
+
+
+class QAVisualAnalysisError(Exception):
+    """Raised when the analysis pipeline fails end to end."""
+
+    def __init__(self, message: str, raw_content: Optional[str] = None):
+        super().__init__(message)
+        self.raw_content = raw_content
+
+
+class QAVisualAnalyzer:
+    """Runs one screenshot through the vision pipeline."""
+
+    def __init__(
+        self,
+        config: Optional[QAVisualConfig] = None,
+        gateway_client: Optional[VisionGatewayClient] = None,
+        store: Optional[QAVisualReportStore] = None,
+    ):
+        self._config = config or QAVisualConfig.from_env()
+        self._gateway = gateway_client or VisionGatewayClient(self._config)
+        self._store = store or QAVisualReportStore(reports_dir=self._config.reports_dir)
+
+    @property
+    def store(self) -> QAVisualReportStore:
+        return self._store
+
+    @property
+    def config(self) -> QAVisualConfig:
+        return self._config
+
+    async def analyze(self, image_bytes: bytes, target: str) -> AnalyzeResponse:
+        """Analyze one screenshot and persist the report."""
+        try:
+            result = await self._gateway.analyze_image(image_bytes)
+        except VisionGatewayError as exc:
+            raise QAVisualAnalysisError(f"Vision gateway failed: {exc}") from exc
+
+        parsed = parse_qa_analysis(result.content)
+        if parsed.parse_error or parsed.analysis is None:
+            raise QAVisualAnalysisError(
+                "Model output could not be parsed into the QA contract",
+                raw_content=result.content,
+            )
+
+        analysis = parsed.analysis
+        baseline = self._store.get_baseline(target)
+        regression_detected = self._detect_regression(analysis, baseline)
+
+        response = AnalyzeResponse(
+            report_id=new_report_id(),
+            target=target,
+            analysis=analysis,
+            passed=analysis.overall_score >= self._config.score_threshold,
+            score=analysis.overall_score,
+            threshold=self._config.score_threshold,
+            cost_usd=result.cost_usd,
+            latency_s=result.latency_s,
+            model=result.model_reported,
+            regression_detected=regression_detected,
+        )
+        self._store.save(response)
+        logger.info(
+            "qa-visual analysis target=%s score=%s passed=%s regression=%s cost=%.6f",
+            target,
+            response.score,
+            response.passed,
+            response.regression_detected,
+            response.cost_usd,
+        )
+        return response
+
+    def _detect_regression(self, analysis, baseline_report: Optional[dict]) -> bool:
+        """Regression = big score drop vs baseline OR regression flags."""
+        if analysis.visual_regression.has_any():
+            return True
+        if not baseline_report:
+            return False
+        baseline_score = baseline_report.get("score")
+        if not isinstance(baseline_score, (int, float)):
+            return False
+        drop = baseline_score - analysis.overall_score
+        return drop >= self._config.degradation_alert_points
+
+    async def close(self) -> None:
+        await self._gateway.close()
+
+
+def build_trend_report(
+    store: QAVisualReportStore,
+    target: Optional[str] = None,
+    limit: int = 50,
+    degradation_points: int = 10,
+) -> Tuple[List[TrendPoint], List[TrendAlert]]:
+    """Build score history and degradation alerts from stored reports.
+
+    Points are returned newest first (mirroring store ordering); alerts are
+    raised whenever consecutive scores drop by ``degradation_points`` or more.
+    """
+    reports = store.list_reports(target=target, limit=limit)
+    points = [
+        TrendPoint(
+            report_id=r.get("report_id", ""),
+            target=r.get("target", ""),
+            timestamp=r.get("timestamp"),
+            score=r.get("score", 0),
+            cost_usd=r.get("cost_usd", 0.0),
+            passed=r.get("passed"),
+        )
+        for r in reports
+    ]
+
+    alerts: List[TrendAlert] = []
+    # reports are newest-first; walk chronologically to compare consecutive runs
+    chronological = list(reversed(reports))
+    for previous, current in zip(chronological, chronological[1:]):
+        previous_score = previous.get("score")
+        current_score = current.get("score")
+        if not isinstance(previous_score, (int, float)) or not isinstance(
+            current_score, (int, float)
+        ):
+            continue
+        if current.get("regression_detected") or (
+            previous_score - current_score >= degradation_points
+        ):
+            alerts.append(
+                TrendAlert(
+                    type="degradation",
+                    target=current.get("target", ""),
+                    message=(
+                        f"Score dropped {int(previous_score - current_score)} points "
+                        f"vs previous run ({int(previous_score)} -> {int(current_score)})"
+                    ),
+                    current_score=int(current_score),
+                    previous_score=int(previous_score),
+                )
+            )
+    return points, alerts

--- a/dashboard/backend/src/infrastructure/qa_visual/config.py
+++ b/dashboard/backend/src/infrastructure/qa_visual/config.py
@@ -1,0 +1,94 @@
+"""QA Visual configuration with spike conditions C1-C5 built in.
+
+C1: thinking:{type:"disabled"} always in QA loops (fast + deterministic).
+C2: max_tokens >= 4000 required when thinking is ON.
+C3: Browser User-Agent on direct HTTP calls to the provider gateway.
+C4: Model id monitored (exp -> GA) via env, never hardcoded in callers.
+C5: Pricing snapshot 2026-08-22 ($0.22/$0.66 per 1M tokens, off-peak).
+
+The API key is read ONLY from the environment (OPENCODE_GO_API_KEY),
+never stored in this repository.
+"""
+
+import os
+from typing import Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+DEFAULT_MODEL = "deepseek-v4-flash-vision-exp"
+DEFAULT_GATEWAY_URL = "https://opencode.ai/zen/go/v1/chat/completions"
+# C3: browser UA required to avoid Cloudflare 1010 rejections.
+BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+)
+# C5: pricing pinned on 2026-08-22 (off-peak rates, USD per 1M tokens).
+PRICING_INPUT_PER_1M_USD = 0.22
+PRICING_OUTPUT_PER_1M_USD = 0.66
+PRICING_SNAPSHOT_DATE = "2026-08-22"
+
+DEFAULT_SCORE_THRESHOLD = 80
+DEFAULT_MAX_TOKENS = 4000
+DEFAULT_REPORTS_DIR = "reports/qa-visual"
+
+
+class QAVisualConfig(BaseModel):
+    """Configuration for the QA Visual module."""
+
+    model: str = Field(default=DEFAULT_MODEL, description="Vision model id (C4: overridable)")
+    gateway_url: str = Field(default=DEFAULT_GATEWAY_URL)
+    user_agent: str = Field(default=BROWSER_USER_AGENT)
+    api_key: Optional[str] = Field(default=None, description="From env only, never committed")
+
+    # C1: thinking disabled by default for QA loops.
+    thinking_enabled: bool = Field(default=False)
+    # C2: >= 4000 when thinking is ON.
+    max_tokens: int = Field(default=DEFAULT_MAX_TOKENS, ge=1)
+
+    temperature: float = Field(default=0.1, ge=0.0, le=2.0)
+    request_timeout_s: float = Field(default=120.0, gt=0)
+
+    score_threshold: int = Field(default=DEFAULT_SCORE_THRESHOLD, ge=0, le=100)
+
+    # C5: pricing pin for cost tracking per analysis.
+    cost_input_per_1m_usd: float = PRICING_INPUT_PER_1M_USD
+    cost_output_per_1m_usd: float = PRICING_OUTPUT_PER_1M_USD
+    pricing_snapshot_date: str = PRICING_SNAPSHOT_DATE
+
+    reports_dir: str = Field(default=DEFAULT_REPORTS_DIR)
+    degradation_alert_points: int = Field(
+        default=10, ge=1, description="Score drop that triggers a trend alert"
+    )
+
+    @model_validator(mode="after")
+    def _validate_thinking_tokens(self) -> "QAVisualConfig":
+        """C2: thinking ON requires max_tokens >= 4000 for complete JSON."""
+        if self.thinking_enabled and self.max_tokens < 4000:
+            raise ValueError(
+                "thinking_enabled=True requires max_tokens >= 4000 (spike condition C2)"
+            )
+        return self
+
+    def calculate_cost_usd(self, prompt_tokens: int, completion_tokens: int) -> float:
+        """Compute analysis cost from token usage with pinned pricing (C5)."""
+        return (
+            prompt_tokens * self.cost_input_per_1m_usd
+            + completion_tokens * self.cost_output_per_1m_usd
+        ) / 1_000_000
+
+    @classmethod
+    def from_env(cls) -> "QAVisualConfig":
+        """Build config from environment variables with safe fallbacks."""
+        threshold_raw = os.environ.get("QA_VISUAL_THRESHOLD_SCORE", "")
+        try:
+            threshold = int(threshold_raw) if threshold_raw else DEFAULT_SCORE_THRESHOLD
+        except ValueError:
+            threshold = DEFAULT_SCORE_THRESHOLD
+
+        return cls(
+            model=os.environ.get("QA_VISUAL_MODEL", DEFAULT_MODEL),
+            gateway_url=os.environ.get("QA_VISUAL_GATEWAY_URL", DEFAULT_GATEWAY_URL),
+            api_key=os.environ.get("OPENCODE_GO_API_KEY"),
+            score_threshold=threshold,
+            reports_dir=os.environ.get("QA_VISUAL_REPORTS_DIR", DEFAULT_REPORTS_DIR),
+        )

--- a/dashboard/backend/src/infrastructure/qa_visual/endpoint.py
+++ b/dashboard/backend/src/infrastructure/qa_visual/endpoint.py
@@ -93,8 +93,12 @@ def create_qa_visual_router(
     async def analyze_screenshot(
         request: Request,
         screenshot: UploadFile = File(..., description="PNG screenshot to analyze"),
+        # S-5R: storage derives the filename as target + 29 bytes of suffix;
+        # 200 + 29 = 229 stays under the 255-byte filesystem name cap. A 255
+        # limit here would let targets of 227-255 chars pass the Form and
+        # then fail with OSError Errno 36 when the report is saved.
         target: str = Form(
-            ..., max_length=255, description="Target name (page/feature identifier)"
+            ..., max_length=200, description="Target name (page/feature identifier)"
         ),
     ) -> AnalyzeResponse:
         """Analyze one screenshot with the vision model and store the report."""

--- a/dashboard/backend/src/infrastructure/qa_visual/endpoint.py
+++ b/dashboard/backend/src/infrastructure/qa_visual/endpoint.py
@@ -1,0 +1,187 @@
+"""FastAPI router for the QA Visual module (same pattern as health/endpoint.py).
+
+Endpoints:
+- POST /analyze          — upload a screenshot, get the full QA report
+- GET  /reports          — list stored reports (filter by target, limit)
+- GET  /reports/{id}     — one stored report
+- GET  /trends           — score history + degradation alerts
+- GET  /baselines/{t}    — baseline report for a target
+
+Example:
+    from fastapi import FastAPI
+    from src.infrastructure.qa_visual import create_qa_visual_router
+
+    app = FastAPI()
+    app.include_router(create_qa_visual_router())
+"""
+
+import logging
+from collections.abc import Sequence
+from typing import Any, Optional
+
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile, status
+
+from src.infrastructure.qa_visual.analyzer import (
+    QAVisualAnalysisError,
+    QAVisualAnalyzer,
+    build_trend_report,
+)
+from src.infrastructure.qa_visual.models import AnalyzeResponse
+
+logger = logging.getLogger(__name__)
+
+MAX_SCREENSHOT_BYTES = 10 * 1024 * 1024  # 10 MB safety cap
+# Headroom for multipart boundaries and form fields when pre-checking
+# Content-Length, so a legitimate 10 MB image is never rejected early.
+MULTIPART_OVERHEAD_ALLOWANCE = 64 * 1024
+PNG_MAGIC_BYTES = b"\x89PNG\r\n\x1a\n"
+CHUNK_SIZE = 64 * 1024
+
+
+async def _read_capped(upload: UploadFile) -> bytes:
+    """Read the upload in chunks, aborting as soon as the size cap is exceeded.
+
+    Never loads an oversized file fully into memory (S-2b).
+    """
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = await upload.read(CHUNK_SIZE)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > MAX_SCREENSHOT_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=f"Screenshot exceeds {MAX_SCREENSHOT_BYTES // (1024 * 1024)} MB",
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def create_qa_visual_router(
+    analyzer: Optional[QAVisualAnalyzer] = None,
+    prefix: str = "/api/v1/qa-visual",
+    dependencies: Optional[Sequence[Any]] = None,
+) -> APIRouter:
+    """Create the QA Visual API router.
+
+    Args:
+        analyzer: pre-configured analyzer (built from env when None)
+        prefix: router prefix
+        dependencies: router-level FastAPI dependencies (e.g. auth).
+            Applied to every endpoint; empty by default so the module
+            stays decoupled from any concrete auth service.
+
+    Returns:
+        FastAPI router with the QA Visual endpoints.
+    """
+    router = APIRouter(
+        prefix=prefix,
+        tags=["qa-visual"],
+        dependencies=list(dependencies) if dependencies else [],
+    )
+    _analyzer = analyzer
+
+    def get_analyzer() -> QAVisualAnalyzer:
+        nonlocal _analyzer
+        if _analyzer is None:
+            _analyzer = QAVisualAnalyzer()  # config from env
+        return _analyzer
+
+    @router.post("/analyze", response_model=AnalyzeResponse)
+    async def analyze_screenshot(
+        request: Request,
+        screenshot: UploadFile = File(..., description="PNG screenshot to analyze"),
+        target: str = Form(
+            ..., max_length=255, description="Target name (page/feature identifier)"
+        ),
+    ) -> AnalyzeResponse:
+        """Analyze one screenshot with the vision model and store the report."""
+        # S-2a: reject oversized uploads before reading the body.
+        content_length = request.headers.get("content-length", "")
+        if content_length.isdigit() and int(content_length) > (
+            MAX_SCREENSHOT_BYTES + MULTIPART_OVERHEAD_ALLOWANCE
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=f"Screenshot exceeds {MAX_SCREENSHOT_BYTES // (1024 * 1024)} MB",
+            )
+        # S-2c: only PNG screenshots are accepted (no paid API calls on junk).
+        if screenshot.content_type != "image/png":
+            raise HTTPException(
+                status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                detail="Screenshot must be image/png",
+            )
+        image_bytes = await _read_capped(screenshot)
+        if not image_bytes:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Empty screenshot upload",
+            )
+        if not image_bytes.startswith(PNG_MAGIC_BYTES):
+            raise HTTPException(
+                status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                detail="Screenshot is not a valid PNG",
+            )
+        try:
+            response = await get_analyzer().analyze(image_bytes, target=target)
+        except QAVisualAnalysisError as exc:
+            # S-3 (CWE-209): full detail goes to server logs only; the HTTP
+            # client gets a generic message.
+            excerpt = (exc.raw_content or "")[:200]
+            logger.error(
+                "QA Visual analysis failed (target=%s): %s%s",
+                target,
+                exc,
+                f" | raw output excerpt: {excerpt}" if excerpt else "",
+            )
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Vision gateway error; see server logs",
+            ) from exc
+        return response
+
+    @router.get("/reports")
+    def list_reports(target: Optional[str] = None, limit: int = 50) -> list:
+        """List stored QA Visual reports (newest first)."""
+        return get_analyzer().store.list_reports(target=target, limit=limit)
+
+    @router.get("/reports/{report_id}")
+    def get_report(report_id: str) -> dict:
+        """Return one stored report by id."""
+        report = get_analyzer().store.get_report(report_id)
+        if report is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Report '{report_id}' not found",
+            )
+        return report
+
+    @router.get("/trends")
+    def get_trends(target: Optional[str] = None, limit: int = 50) -> dict:
+        """Score history and degradation alerts (dashboard data source)."""
+        analyzer = get_analyzer()
+        points, alerts = build_trend_report(
+            analyzer.store,
+            target=target,
+            limit=limit,
+            degradation_points=analyzer.config.degradation_alert_points,
+        )
+        return {
+            "points": [p.model_dump() for p in points],
+            "alerts": [a.model_dump() for a in alerts],
+        }
+
+    @router.get("/baselines/{target}")
+    def get_baseline(target: str) -> dict:
+        """Return the baseline (earliest) report for a target."""
+        baseline = get_analyzer().store.get_baseline(target)
+        if baseline is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No baseline found for target '{target}'",
+            )
+        return baseline
+
+    return router

--- a/dashboard/backend/src/infrastructure/qa_visual/gateway_client.py
+++ b/dashboard/backend/src/infrastructure/qa_visual/gateway_client.py
@@ -1,0 +1,164 @@
+"""Async client for the vision model gateway (spike conditions C1-C5).
+
+C1: thinking disabled by default (4.37s vs 10-23s with thinking ON).
+C2: max_tokens >= 4000 enforced by config when thinking is ON.
+C3: browser User-Agent on every request (Cloudflare 1010 mitigation).
+C4: model id from config (exp -> GA transition without code changes).
+C5: per-analysis cost tracking with pinned 2026-08-22 pricing.
+"""
+
+import base64
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import httpx
+
+from src.infrastructure.qa_visual.config import QAVisualConfig
+
+logger = logging.getLogger(__name__)
+
+QA_PROMPT = """Eres un QA visual automatizado para SabaTech. Analiza esta captura de pantalla y responde en formato JSON con esta estructura EXACTA:
+
+{
+  "page_title": "título exacto visible o null",
+  "visible_texts": ["lista de TODOS los textos literales visibles (botones, labels, placeholders, headings, footer, etc.)"],
+  "layout": {
+    "description": "descripción del layout (elementos, orden, alineación)",
+    "colors": {"background": "#hex", "primary_accent": "#hex", "text": "#hex"}
+  },
+  "qa_issues": [
+    {
+      "severity": "critical|high|medium|low|info",
+      "category": "contrast|alignment|overflow|missing|text|spacing|other",
+      "description": "descripción del problema",
+      "element": "elemento afectado si identificable"
+    }
+  ],
+  "accessibility": {
+    "contrast_issues": ["lista de problemas de contraste WCAG"],
+    "missing_alt": true/false,
+    "missing_labels": ["inputs sin label"]
+  },
+  "visual_regression": {
+    "unexpected_whitespace": true/false,
+    "overlapping_elements": true/false,
+    "cut_off_content": true/false,
+    "misaligned": true/false
+  },
+  "overall_score": 0-100,
+  "summary": "resumen en 1-2 oraciones"
+}
+
+Responde SOLO con el JSON, sin texto adicional."""
+
+
+class VisionGatewayError(Exception):
+    """Raised when the gateway call fails or returns an unusable response."""
+
+
+@dataclass
+class VisionResult:
+    """Raw result of one gateway call."""
+
+    content: str
+    latency_s: float
+    usage: Dict[str, Any]
+    cost_usd: float
+    model_reported: str
+    finish_reason: Optional[str]
+
+
+class VisionGatewayClient:
+    """Talks to the vision gateway with spike conditions baked in."""
+
+    def __init__(self, config: QAVisualConfig, http_client: Optional[httpx.AsyncClient] = None):
+        self._config = config
+        self._owns_client = http_client is None
+        self._client = http_client or httpx.AsyncClient(timeout=config.request_timeout_s)
+
+    async def analyze_image(self, image_bytes: bytes) -> VisionResult:
+        """Send a PNG screenshot for QA analysis and return the raw result."""
+        if not self._config.api_key:
+            raise VisionGatewayError("API key missing: set OPENCODE_GO_API_KEY in the environment")
+
+        payload = self._build_payload(image_bytes)
+        headers = {
+            "Authorization": f"Bearer {self._config.api_key}",
+            "Content-Type": "application/json",
+            # C3: browser UA required by the gateway.
+            "User-Agent": self._config.user_agent,
+        }
+
+        started = time.monotonic()
+        try:
+            response = await self._client.post(
+                self._config.gateway_url,
+                content=json.dumps(payload),
+                headers=headers,
+            )
+        except httpx.TimeoutException as exc:
+            raise VisionGatewayError(f"Gateway timeout: {exc}") from exc
+        except httpx.HTTPError as exc:
+            raise VisionGatewayError(f"Gateway connection error: {exc}") from exc
+
+        latency_s = time.monotonic() - started
+        if response.status_code != 200:
+            # S-3 (CWE-209): upstream body stays in server logs only, never
+            # in the exception message that could reach an HTTP client.
+            logger.error("Gateway HTTP %s: %s", response.status_code, response.text[:200])
+            raise VisionGatewayError(f"Gateway HTTP {response.status_code}")
+
+        try:
+            body = response.json()
+            choice = body["choices"][0]
+            content = choice["message"].get("content", "")
+            usage = body.get("usage", {}) or {}
+        except (ValueError, KeyError, IndexError, TypeError) as exc:
+            raise VisionGatewayError(f"Malformed gateway response: {exc}") from exc
+
+        cost_usd = self._config.calculate_cost_usd(
+            prompt_tokens=usage.get("prompt_tokens", 0) or 0,
+            completion_tokens=usage.get("completion_tokens", 0) or 0,
+        )
+
+        return VisionResult(
+            content=content,
+            latency_s=round(latency_s, 2),
+            usage=usage,
+            cost_usd=round(cost_usd, 6),
+            model_reported=body.get("model", "unknown"),
+            finish_reason=choice.get("finish_reason"),
+        )
+
+    def _build_payload(self, image_bytes: bytes) -> Dict[str, Any]:
+        data_url = "data:image/png;base64," + base64.b64encode(image_bytes).decode()
+        payload: Dict[str, Any] = {
+            "model": self._config.model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": QA_PROMPT},
+                        {"type": "image_url", "image_url": {"url": data_url}},
+                    ],
+                }
+            ],
+            "max_tokens": self._config.max_tokens,
+            "temperature": self._config.temperature,
+            # C1: thinking disabled for QA loops (fast + deterministic).
+            "thinking": {"type": "disabled" if not self._config.thinking_enabled else "enabled"},
+        }
+        return payload
+
+    async def close(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def __aenter__(self) -> "VisionGatewayClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()

--- a/dashboard/backend/src/infrastructure/qa_visual/models.py
+++ b/dashboard/backend/src/infrastructure/qa_visual/models.py
@@ -1,0 +1,126 @@
+"""Pydantic models for the QA Visual module.
+
+The QAAnalysis contract mirrors the exact JSON structure the vision model
+is prompted to return (validated in Fase A: 5/5 literal texts, 0 hallucinations).
+"""
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class Severity(str, Enum):
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    INFO = "info"
+
+
+class IssueCategory(str, Enum):
+    CONTRAST = "contrast"
+    ALIGNMENT = "alignment"
+    OVERFLOW = "overflow"
+    MISSING = "missing"
+    TEXT = "text"
+    SPACING = "spacing"
+    OTHER = "other"
+
+
+class QAIssue(BaseModel):
+    """A single QA issue detected on the screenshot."""
+
+    severity: Severity = Severity.INFO
+    category: IssueCategory = IssueCategory.OTHER
+    description: str = ""
+    element: Optional[str] = None
+
+
+class LayoutInfo(BaseModel):
+    description: str = ""
+    colors: Optional[Dict[str, str]] = None
+
+
+class Accessibility(BaseModel):
+    contrast_issues: List[str] = Field(default_factory=list)
+    missing_alt: bool = False
+    missing_labels: List[str] = Field(default_factory=list)
+
+
+class VisualRegression(BaseModel):
+    """Regression flags reported by the vision model."""
+
+    unexpected_whitespace: bool = False
+    overlapping_elements: bool = False
+    cut_off_content: bool = False
+    misaligned: bool = False
+
+    def has_any(self) -> bool:
+        return any(
+            (
+                self.unexpected_whitespace,
+                self.overlapping_elements,
+                self.cut_off_content,
+                self.misaligned,
+            )
+        )
+
+
+class QAAnalysis(BaseModel):
+    """Structured result the vision model must return for one screenshot."""
+
+    page_title: Optional[str] = None
+    visible_texts: List[str] = Field(default_factory=list)
+    layout: Optional[LayoutInfo] = None
+    qa_issues: List[QAIssue] = Field(default_factory=list)
+    accessibility: Accessibility = Field(default_factory=Accessibility)
+    visual_regression: VisualRegression = Field(default_factory=VisualRegression)
+    overall_score: int = Field(ge=0, le=100)
+    summary: str = ""
+
+
+class AnalyzeResponse(BaseModel):
+    """Full analysis report returned by the endpoint and persisted."""
+
+    report_id: str
+    target: str
+    analysis: QAAnalysis
+    passed: bool
+    score: int
+    threshold: int
+    cost_usd: float
+    latency_s: float
+    model: str
+    regression_detected: bool = False
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class TrendPoint(BaseModel):
+    """One point in the score history of a target."""
+
+    report_id: str
+    target: str
+    timestamp: Optional[datetime] = None
+    score: int
+    cost_usd: float = 0.0
+    passed: Optional[bool] = None
+
+
+class TrendAlert(BaseModel):
+    """Alert raised from the trend analysis (e.g. score degradation)."""
+
+    type: str
+    target: str
+    message: str
+    current_score: Optional[int] = None
+    previous_score: Optional[int] = None
+
+    @model_validator(mode="after")
+    def _validate_degradation_scores(self) -> "TrendAlert":
+        if self.type == "degradation" and (
+            self.current_score is None or self.previous_score is None
+        ):
+            raise ValueError("degradation alerts require current_score and previous_score")
+        return self

--- a/dashboard/backend/src/infrastructure/qa_visual/parser.py
+++ b/dashboard/backend/src/infrastructure/qa_visual/parser.py
@@ -1,0 +1,107 @@
+"""Robust parsing of vision model output into the QAAnalysis contract.
+
+The model is prompted to return raw JSON, but responses can include markdown
+fences or leading prose. This parser extracts the first valid JSON object and
+validates it against the contract; unknown enum values degrade gracefully
+instead of failing the whole analysis.
+"""
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from pydantic import ValidationError
+
+from src.infrastructure.qa_visual.models import QAIssue, QAAnalysis
+
+# Extracts the outermost {...} block, ignoring braces inside strings.
+_JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+@dataclass
+class ParseResult:
+    """Outcome of parsing the model content."""
+
+    analysis: Optional[QAAnalysis] = None
+    parse_error: bool = False
+    raw_content: str = ""
+
+
+def _extract_json_text(content: str) -> Optional[str]:
+    """Extract candidate JSON text, handling fences and leading prose."""
+    text = content.strip()
+    if not text:
+        return None
+    if text.startswith("```"):
+        # Strip markdown fence lines (with or without language tag).
+        lines = [line for line in text.split("\n") if not line.strip().startswith("```")]
+        text = "\n".join(lines).strip()
+    if text.startswith("{"):
+        return text
+    match = _JSON_OBJECT_RE.search(text)
+    return match.group(0) if match else None
+
+
+def parse_qa_analysis(content: str) -> ParseResult:
+    """Parse model output into a validated QAAnalysis.
+
+    Returns ParseResult with parse_error=True and the raw content when the
+    output cannot be parsed or does not satisfy the contract.
+    """
+    json_text = _extract_json_text(content)
+    if json_text is None:
+        return ParseResult(analysis=None, parse_error=True, raw_content=content)
+
+    try:
+        data = json.loads(json_text)
+    except json.JSONDecodeError:
+        return ParseResult(analysis=None, parse_error=True, raw_content=content)
+
+    if not isinstance(data, dict):
+        return ParseResult(analysis=None, parse_error=True, raw_content=content)
+
+    try:
+        analysis = QAAnalysis.model_validate(data)
+    except ValidationError:
+        # Retry with degraded tolerance: drop invalid issues instead of failing.
+        analysis = _coerce_lenient(data)
+        if analysis is None:
+            return ParseResult(analysis=None, parse_error=True, raw_content=content)
+
+    return ParseResult(analysis=analysis, parse_error=False)
+
+
+def _coerce_lenient(data: dict) -> Optional[QAAnalysis]:
+    """Best-effort coercion: unknown severities/categories fall back to defaults."""
+    if "overall_score" not in data:
+        return None
+    valid_keys = {"severity", "category", "description", "element"}
+    issues = []
+    for issue in data.get("qa_issues") or []:
+        if not isinstance(issue, dict):
+            continue
+        candidate = {k: v for k, v in issue.items() if k in valid_keys}
+        try:
+            issues.append(QAIssue.model_validate(candidate))
+            continue
+        except ValidationError:
+            pass
+        # Drop invalid enum values and retry with the remaining fields.
+        cleaned = dict(candidate)
+        for key in ("severity", "category"):
+            if key in cleaned:
+                try:
+                    QAIssue.model_validate({key: cleaned[key], "description": ""})
+                except ValidationError:
+                    cleaned.pop(key, None)
+        try:
+            issues.append(QAIssue.model_validate(cleaned))
+        except ValidationError:
+            continue
+    patched = dict(data)
+    patched["qa_issues"] = [issue.model_dump() for issue in issues]
+    try:
+        return QAAnalysis.model_validate(patched)
+    except ValidationError:
+        return None

--- a/dashboard/backend/src/infrastructure/qa_visual/playwright_hook.py
+++ b/dashboard/backend/src/infrastructure/qa_visual/playwright_hook.py
@@ -1,0 +1,92 @@
+"""Playwright E2E post-test hook for QA Visual analysis.
+
+After a test finishes, the hook captures a screenshot of the page, sends it
+through the QA Visual analyzer and appends the resulting report to the test's
+JSON report file under a ``qa_visual`` key.
+
+Design rules:
+- Duck typing: any object with ``await screenshot(path=...)`` works, so both
+  Playwright pages and test doubles can be passed in.
+- Fail-soft: a QA hook must never break the E2E suite it observes. All errors
+  are logged and swallowed, returning None.
+"""
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Optional, Union
+
+from src.infrastructure.qa_visual.analyzer import QAVisualAnalyzer
+from src.infrastructure.qa_visual.models import AnalyzeResponse
+
+logger = logging.getLogger(__name__)
+
+
+def _sanitize_test_name(test_name: str) -> str:
+    sanitized = re.sub(r"[^a-zA-Z0-9_-]+", "-", test_name).strip("-")
+    return sanitized or "unnamed-test"
+
+
+class QAVisualHook:
+    """Post-test hook: screenshot -> vision analysis -> test report append."""
+
+    def __init__(
+        self, analyzer: QAVisualAnalyzer, screenshots_dir: str = "reports/qa-visual/screenshots"
+    ):
+        self._analyzer = analyzer
+        self._screenshots_dir = Path(screenshots_dir)
+
+    async def on_test_end(
+        self,
+        page,
+        test_name: str,
+        report_path: Optional[Union[str, Path]] = None,
+    ) -> Optional[AnalyzeResponse]:
+        """Capture, analyze and record. Never raises.
+
+        Args:
+            page: object exposing ``await page.screenshot(path=...)``
+            test_name: test (or page) identifier used as analysis target
+            report_path: optional JSON test report to append the result to
+
+        Returns:
+            The AnalyzeResponse, or None when the hook failed softly.
+        """
+        safe_name = _sanitize_test_name(test_name)
+        try:
+            screenshot_path = await self._capture(page, safe_name)
+            image_bytes = screenshot_path.read_bytes()
+            response = await self._analyzer.analyze(image_bytes, target=test_name)
+        except Exception:
+            logger.exception("qa-visual hook failed for %s (ignored)", safe_name)
+            return None
+
+        if report_path:
+            try:
+                self._append_to_report(Path(report_path), response)
+            except Exception:
+                logger.exception(
+                    "qa-visual hook could not update test report %s (ignored)", report_path
+                )
+        return response
+
+    async def _capture(self, page, safe_name: str) -> Path:
+        self._screenshots_dir.mkdir(parents=True, exist_ok=True)
+        path = self._screenshots_dir / f"{safe_name}.png"
+        # Duck-typed call: works with playwright Page and PlaywrightPage alike.
+        await page.screenshot(path=str(path))
+        return path
+
+    def _append_to_report(self, report_path: Path, response: AnalyzeResponse) -> None:
+        data = {}
+        if report_path.exists():
+            try:
+                data = json.loads(report_path.read_text())
+            except json.JSONDecodeError:
+                logger.warning(
+                    "qa-visual: test report %s is not valid JSON, recreating", report_path
+                )
+                data = {}
+        data["qa_visual"] = response.model_dump(mode="json")
+        report_path.write_text(json.dumps(data, indent=2))

--- a/dashboard/backend/src/infrastructure/qa_visual/storage.py
+++ b/dashboard/backend/src/infrastructure/qa_visual/storage.py
@@ -1,0 +1,91 @@
+"""JSON-file persistence for QA Visual reports.
+
+Follows the GO-NOGO Fase B direction: reports live under ``reports/qa-visual/``
+as self-contained JSON documents (same shape as the Fase A spike reports).
+The store is an abstraction so the backend can be swapped for SQLite/Postgres
+without touching the analyzer or the endpoint (DIP).
+
+Filenames are ``qa_visual_<target>_<report_id>.json`` with the target
+sanitised, and the report id is embedded in each document so lookups never
+depend on filename parsing.
+"""
+
+import json
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from src.infrastructure.qa_visual.models import AnalyzeResponse
+
+
+def new_report_id() -> str:
+    """Generate a unique report id."""
+    return uuid.uuid4().hex[:12]
+
+
+def _sanitize_target(target: str) -> str:
+    """Make a target safe for filenames."""
+    sanitized = re.sub(r"[^a-z0-9_-]+", "-", target.lower()).strip("-")
+    return sanitized or "unknown"
+
+
+class QAVisualReportStore:
+    """Saves and queries QA Visual reports as JSON files."""
+
+    def __init__(self, reports_dir: str):
+        self._dir = Path(reports_dir)
+
+    @property
+    def reports_dir(self) -> Path:
+        return self._dir
+
+    def save(self, response: AnalyzeResponse) -> Path:
+        """Persist one report and return its path."""
+        self._dir.mkdir(parents=True, exist_ok=True)
+        response.report_id = response.report_id or new_report_id()
+        if not response.timestamp or response.timestamp.year < 2000:
+            response.timestamp = datetime.now(timezone.utc)
+        path = (
+            self._dir / f"qa_visual_{_sanitize_target(response.target)}_{response.report_id}.json"
+        )
+        path.write_text(response.model_dump_json(indent=2))
+        return path
+
+    def list_reports(
+        self, target: Optional[str] = None, limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """List reports (newest first), optionally filtered by target."""
+        reports = []
+        for path in self._dir.glob("*.json") if self._dir.exists() else []:
+            report = self._read_report(path)
+            if report is None:
+                continue
+            if target and report.get("target") != target:
+                continue
+            reports.append(report)
+        reports.sort(key=lambda r: r.get("timestamp") or "", reverse=True)
+        return reports[:limit] if limit else reports
+
+    def get_report(self, report_id: str) -> Optional[Dict[str, Any]]:
+        """Return one report by id, or None."""
+        for path in self._dir.glob("*.json") if self._dir.exists() else []:
+            report = self._read_report(path)
+            if report and report.get("report_id") == report_id:
+                return report
+        return None
+
+    def get_baseline(self, target: str) -> Optional[Dict[str, Any]]:
+        """Return the earliest report for a target (its visual baseline)."""
+        reports = self.list_reports(target=target)
+        if not reports:
+            return None
+        return min(reports, key=lambda r: r.get("timestamp") or "")
+
+    @staticmethod
+    def _read_report(path: Path) -> Optional[Dict[str, Any]]:
+        try:
+            return json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None

--- a/dashboard/backend/tests/test_qa_visual_feature_flag.py
+++ b/dashboard/backend/tests/test_qa_visual_feature_flag.py
@@ -36,4 +36,4 @@ class TestQAVisualRouterFeatureFlag:
     def test_router_mounted_with_flag_returns_401_without_credentials(self, monkeypatch):
         monkeypatch.setenv("QA_VISUAL_ENABLED", "1")
         client = _client_with_fresh_main()
-        assert client.get(REPORTS_PATH).status_code == 401
+        assert client.get(REPORTS_PATH).status_code in (401, 403)

--- a/dashboard/backend/tests/test_qa_visual_feature_flag.py
+++ b/dashboard/backend/tests/test_qa_visual_feature_flag.py
@@ -1,0 +1,39 @@
+"""Feature-flag tests for the QA Visual router mount (Fase C — S-1R).
+
+The dashboard is multi-tenant without roles and the QA Visual report store
+is global, so mounting the router exposes a cross-tenant BOLA surface
+(CVSS 5.4). Until reports are scoped by owner (or roles exist), the router
+must stay UNMOUNTED in deploys unless ``QA_VISUAL_ENABLED=1`` is set
+explicitly:
+
+- flag unset  -> every qa-visual endpoint returns 404 (router not mounted)
+- flag = "1"  -> router mounted behind JWT auth: 401 without credentials
+
+``main`` builds the app at import time, so each case reloads the module
+under a controlled environment. The wiring tests reload it back with the
+flag on; ordering between both files is therefore irrelevant.
+"""
+
+import importlib
+
+from fastapi.testclient import TestClient
+
+REPORTS_PATH = "/api/v1/qa-visual/reports"
+
+
+def _client_with_fresh_main() -> TestClient:
+    import main as dashboard_main
+
+    return TestClient(importlib.reload(dashboard_main).app)
+
+
+class TestQAVisualRouterFeatureFlag:
+    def test_router_not_mounted_without_flag(self, monkeypatch):
+        monkeypatch.delenv("QA_VISUAL_ENABLED", raising=False)
+        client = _client_with_fresh_main()
+        assert client.get(REPORTS_PATH).status_code == 404
+
+    def test_router_mounted_with_flag_returns_401_without_credentials(self, monkeypatch):
+        monkeypatch.setenv("QA_VISUAL_ENABLED", "1")
+        client = _client_with_fresh_main()
+        assert client.get(REPORTS_PATH).status_code == 401

--- a/dashboard/backend/tests/test_qa_visual_wiring.py
+++ b/dashboard/backend/tests/test_qa_visual_wiring.py
@@ -1,14 +1,22 @@
 """Wiring tests for the QA Visual router in the dashboard (Fase C — card 0ddedd75).
 
-S-1: dashboard/backend/main.py mounts the vendored qa_visual router with
-``dependencies=[Depends(get_current_user)]``. Every endpoint must reject
-unauthenticated requests on the REAL app: 403 without an Authorization
-header (HTTPBearer semantics) and 401 with a malformed bearer token.
+S-1/S-1R: dashboard/backend/main.py mounts the vendored qa_visual router —
+gated behind QA_VISUAL_ENABLED=1 — with ``dependencies=[Depends(get_current_user)]``.
+Every endpoint must reject unauthenticated requests on the REAL app.
+Without credentials the response is 401 or 403 depending on the stack's
+HTTPBearer handling (this one answers 401 "Not authenticated"); with a
+malformed bearer token get_current_user answers 401.
+
+The flag must be set BEFORE main is imported because the app (and the
+conditional router mount) is built at import time; the fixture reloads
+main under the flag so ordering vs. test_qa_visual_feature_flag.py is
+irrelevant.
 
 A hand-built app with an injected fake analyzer proves the authenticated
 happy path, so no paid gateway call or real report dir is touched.
 """
 
+import importlib
 import io
 from unittest.mock import AsyncMock
 
@@ -36,9 +44,14 @@ GET_PATHS = [
 
 @pytest.fixture(scope="module")
 def main_app():
+    # S-1R: build the app with the router actually mounted.
+    mp = pytest.MonkeyPatch()
+    mp.setenv("QA_VISUAL_ENABLED", "1")
     import main as dashboard_main
 
-    return dashboard_main.app
+    app = importlib.reload(dashboard_main).app
+    yield app
+    mp.undo()
 
 
 @pytest.fixture(scope="module")
@@ -49,17 +62,17 @@ def main_client(main_app):
 class TestMainAppAuthEnforcement:
     """The real dashboard app must enforce auth on all five endpoints."""
 
-    def test_no_credentials_403_all_get_endpoints(self, main_client):
+    def test_no_credentials_rejected_all_get_endpoints(self, main_client):
         for path in GET_PATHS:
-            assert main_client.get(path).status_code == 403, path
+            assert main_client.get(path).status_code in (401, 403), path
 
-    def test_no_credentials_403_analyze(self, main_client):
+    def test_no_credentials_rejected_analyze(self, main_client):
         response = main_client.post(
             "/api/v1/qa-visual/analyze",
             files={"screenshot": ("page.png", PNG_BYTES, "image/png")},
             data={"target": "amc"},
         )
-        assert response.status_code == 403
+        assert response.status_code in (401, 403)
 
     def test_malformed_token_401_all_endpoints(self, main_client):
         headers = {"Authorization": "Bearer not.a.jwt"}

--- a/dashboard/backend/tests/test_qa_visual_wiring.py
+++ b/dashboard/backend/tests/test_qa_visual_wiring.py
@@ -1,0 +1,142 @@
+"""Wiring tests for the QA Visual router in the dashboard (Fase C — card 0ddedd75).
+
+S-1: dashboard/backend/main.py mounts the vendored qa_visual router with
+``dependencies=[Depends(get_current_user)]``. Every endpoint must reject
+unauthenticated requests on the REAL app: 403 without an Authorization
+header (HTTPBearer semantics) and 401 with a malformed bearer token.
+
+A hand-built app with an injected fake analyzer proves the authenticated
+happy path, so no paid gateway call or real report dir is touched.
+"""
+
+import io
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from src.infrastructure.qa_visual import (
+    QAVisualAnalyzer,
+    create_qa_visual_router,
+)
+from src.infrastructure.qa_visual.config import QAVisualConfig
+from src.infrastructure.qa_visual.models import AnalyzeResponse, QAAnalysis
+from src.infrastructure.qa_visual.storage import QAVisualReportStore
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\nfakepngdata"
+
+GET_PATHS = [
+    "/api/v1/qa-visual/reports",
+    "/api/v1/qa-visual/reports/rep-001",
+    "/api/v1/qa-visual/trends",
+    "/api/v1/qa-visual/baselines/amc",
+]
+
+
+@pytest.fixture(scope="module")
+def main_app():
+    import main as dashboard_main
+
+    return dashboard_main.app
+
+
+@pytest.fixture(scope="module")
+def main_client(main_app):
+    return TestClient(main_app)
+
+
+class TestMainAppAuthEnforcement:
+    """The real dashboard app must enforce auth on all five endpoints."""
+
+    def test_no_credentials_403_all_get_endpoints(self, main_client):
+        for path in GET_PATHS:
+            assert main_client.get(path).status_code == 403, path
+
+    def test_no_credentials_403_analyze(self, main_client):
+        response = main_client.post(
+            "/api/v1/qa-visual/analyze",
+            files={"screenshot": ("page.png", PNG_BYTES, "image/png")},
+            data={"target": "amc"},
+        )
+        assert response.status_code == 403
+
+    def test_malformed_token_401_all_endpoints(self, main_client):
+        headers = {"Authorization": "Bearer not.a.jwt"}
+        for path in GET_PATHS:
+            response = main_client.get(path, headers=headers)
+            assert response.status_code == 401, path
+        response = main_client.post(
+            "/api/v1/qa-visual/analyze",
+            files={"screenshot": ("page.png", PNG_BYTES, "image/png")},
+            data={"target": "amc"},
+            headers=headers,
+        )
+        assert response.status_code == 401
+
+
+class TestAuthenticatedHappyPath:
+    """With auth bypassed and a fake analyzer, the mounted router serves."""
+
+    @pytest.fixture()
+    def authed_client(self, tmp_path):
+        store = QAVisualReportStore(reports_dir=str(tmp_path / "qa-visual"))
+        sample = AnalyzeResponse(
+            report_id="rep-001",
+            target="amc",
+            analysis=QAAnalysis(overall_score=95, summary="clean"),
+            passed=True,
+            score=95,
+            threshold=80,
+            cost_usd=0.000428,
+            latency_s=4.37,
+            model="deepseek-v4-flash-vision-exp",
+            regression_detected=False,
+        )
+        store.save(sample)
+        analyzer = QAVisualAnalyzer.__new__(QAVisualAnalyzer)
+        analyzer._config = QAVisualConfig()
+        analyzer._store = store
+        analyzer.analyze = AsyncMock(return_value=sample)
+
+        app = FastAPI()
+        app.include_router(
+            create_qa_visual_router(analyzer=analyzer, dependencies=[Depends(lambda: "fake-user")])
+        )
+        return TestClient(app)
+
+    def test_authed_reports_list(self, authed_client):
+        response = authed_client.get("/api/v1/qa-visual/reports")
+        assert response.status_code == 200
+        assert response.json()[0]["report_id"] == "rep-001"
+
+    def test_authed_report_by_id(self, authed_client):
+        response = authed_client.get("/api/v1/qa-visual/reports/rep-001")
+        assert response.status_code == 200
+        assert response.json()["report_id"] == "rep-001"
+
+    def test_authed_report_by_id_not_found(self, authed_client):
+        assert authed_client.get("/api/v1/qa-visual/reports/missing").status_code == 404
+
+    def test_authed_trends(self, authed_client):
+        response = authed_client.get("/api/v1/qa-visual/trends")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["points"][0]["target"] == "amc"
+
+    def test_authed_baseline(self, authed_client):
+        response = authed_client.get("/api/v1/qa-visual/baselines/amc")
+        assert response.status_code == 200
+        assert response.json()["target"] == "amc"
+
+    def test_authed_baseline_not_found(self, authed_client):
+        assert authed_client.get("/api/v1/qa-visual/baselines/nope").status_code == 404
+
+    def test_authed_analyze_reaches_analyzer(self, authed_client):
+        response = authed_client.post(
+            "/api/v1/qa-visual/analyze",
+            files={"screenshot": ("page.png", io.BytesIO(PNG_BYTES), "image/png")},
+            data={"target": "amc"},
+        )
+        assert response.status_code == 200
+        assert response.json()["report_id"] == "rep-001"

--- a/docs/qa-visual.md
+++ b/docs/qa-visual.md
@@ -57,6 +57,51 @@ app = FastAPI()
 app.include_router(create_qa_visual_router())  # config from env
 ```
 
+The factory accepts injectable router-level `dependencies` so the mounter
+controls authentication without coupling the module to any auth service
+(security hardening S-1):
+
+```python
+from fastapi import Depends
+app.include_router(
+    create_qa_visual_router(dependencies=[Depends(get_current_user)])
+)
+```
+
+### Dashboard wiring (Fase C)
+
+The dashboard backend (`dashboard/backend/main.py`) mounts the router with
+`dependencies=[Depends(get_current_user)]`: **all five endpoints require a
+valid JWT**. Because the Docker build context only ships `dashboard/backend`,
+the module is vendored at `dashboard/backend/src/infrastructure/qa_visual/`
+(same pattern as the cache module). A parity test
+(`tests/unit/infrastructure/test_qa_visual_vendor_parity.py`) fails loudly if
+the two copies drift — after changing `src/infrastructure/qa_visual/`, re-copy:
+
+```bash
+cp src/infrastructure/qa_visual/*.py dashboard/backend/src/infrastructure/qa_visual/
+```
+
+Upload hardening (S-2/S-5) applies to `POST /analyze`: `Content-Length`
+pre-check + chunked read capped at 10 MB (413), `image/png` content-type and
+PNG magic-byte validation (415), and `target` limited to 255 chars (422).
+Upstream gateway errors return a generic 502 with full detail in server logs
+only (S-3, CWE-209).
+
+### Data handling (S-4)
+
+Every `POST /analyze` call sends the **full screenshot** (base64, up to ~13 MB
+payload for a 10 MB image) to the external vision gateway
+(`https://opencode.ai/zen/go/v1/chat/completions`). Policy:
+
+- **Synthetic/test data only** — QA Visual targets must not contain real PII,
+  customer data or credentials. If screenshots may capture real user data,
+  evaluate GDPR Art. 32 (processor transfer) and add pre-send redaction
+  before enabling the module in that environment.
+- Reports and screenshots stored under `reports/qa-visual/` are runtime
+  artifacts; the directory is gitignored to prevent accidental commits.
+
+
 ### Analyze a screenshot
 
 ```http

--- a/docs/qa-visual.md
+++ b/docs/qa-visual.md
@@ -72,7 +72,12 @@ app.include_router(
 
 The dashboard backend (`dashboard/backend/main.py`) mounts the router with
 `dependencies=[Depends(get_current_user)]`: **all five endpoints require a
-valid JWT**. Because the Docker build context only ships `dashboard/backend`,
+valid JWT**. The mount is **gated behind `QA_VISUAL_ENABLED=1` (default
+off)** — without the flag the router is not mounted and every qa-visual
+endpoint returns 404. The dashboard is multi-tenant without roles and the
+report store is global, so the flag must stay off until reports are
+owner-scoped (security finding S-1R). Because the Docker build context only
+ships `dashboard/backend`,
 the module is vendored at `dashboard/backend/src/infrastructure/qa_visual/`
 (same pattern as the cache module). A parity test
 (`tests/unit/infrastructure/test_qa_visual_vendor_parity.py`) fails loudly if
@@ -84,7 +89,7 @@ cp src/infrastructure/qa_visual/*.py dashboard/backend/src/infrastructure/qa_vis
 
 Upload hardening (S-2/S-5) applies to `POST /analyze`: `Content-Length`
 pre-check + chunked read capped at 10 MB (413), `image/png` content-type and
-PNG magic-byte validation (415), and `target` limited to 255 chars (422).
+PNG magic-byte validation (415), and `target` limited to 200 chars (422).
 Upstream gateway errors return a generic 502 with full detail in server logs
 only (S-3, CWE-209).
 
@@ -145,7 +150,8 @@ Content-Type: multipart/form-data
 ```
 
 Errors: `422` (missing/empty fields), `413` (screenshot > 10 MB),
-`502` (gateway or model-output failure, includes a raw output excerpt).
+`502` (gateway or model-output failure, generic body — details in server
+logs only).
 
 ### Reports and trends
 

--- a/src/infrastructure/qa_visual/endpoint.py
+++ b/src/infrastructure/qa_visual/endpoint.py
@@ -93,8 +93,12 @@ def create_qa_visual_router(
     async def analyze_screenshot(
         request: Request,
         screenshot: UploadFile = File(..., description="PNG screenshot to analyze"),
+        # S-5R: storage derives the filename as target + 29 bytes of suffix;
+        # 200 + 29 = 229 stays under the 255-byte filesystem name cap. A 255
+        # limit here would let targets of 227-255 chars pass the Form and
+        # then fail with OSError Errno 36 when the report is saved.
         target: str = Form(
-            ..., max_length=255, description="Target name (page/feature identifier)"
+            ..., max_length=200, description="Target name (page/feature identifier)"
         ),
     ) -> AnalyzeResponse:
         """Analyze one screenshot with the vision model and store the report."""

--- a/src/infrastructure/qa_visual/endpoint.py
+++ b/src/infrastructure/qa_visual/endpoint.py
@@ -16,9 +16,10 @@ Example:
 """
 
 import logging
-from typing import Optional
+from collections.abc import Sequence
+from typing import Any, Optional
 
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile, status
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile, status
 
 from src.infrastructure.qa_visual.analyzer import (
     QAVisualAnalysisError,
@@ -30,22 +31,56 @@ from src.infrastructure.qa_visual.models import AnalyzeResponse
 logger = logging.getLogger(__name__)
 
 MAX_SCREENSHOT_BYTES = 10 * 1024 * 1024  # 10 MB safety cap
+# Headroom for multipart boundaries and form fields when pre-checking
+# Content-Length, so a legitimate 10 MB image is never rejected early.
+MULTIPART_OVERHEAD_ALLOWANCE = 64 * 1024
+PNG_MAGIC_BYTES = b"\x89PNG\r\n\x1a\n"
+CHUNK_SIZE = 64 * 1024
+
+
+async def _read_capped(upload: UploadFile) -> bytes:
+    """Read the upload in chunks, aborting as soon as the size cap is exceeded.
+
+    Never loads an oversized file fully into memory (S-2b).
+    """
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = await upload.read(CHUNK_SIZE)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > MAX_SCREENSHOT_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=f"Screenshot exceeds {MAX_SCREENSHOT_BYTES // (1024 * 1024)} MB",
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def create_qa_visual_router(
     analyzer: Optional[QAVisualAnalyzer] = None,
     prefix: str = "/api/v1/qa-visual",
+    dependencies: Optional[Sequence[Any]] = None,
 ) -> APIRouter:
     """Create the QA Visual API router.
 
     Args:
         analyzer: pre-configured analyzer (built from env when None)
         prefix: router prefix
+        dependencies: router-level FastAPI dependencies (e.g. auth).
+            Applied to every endpoint; empty by default so the module
+            stays decoupled from any concrete auth service.
 
     Returns:
         FastAPI router with the QA Visual endpoints.
     """
-    router = APIRouter(prefix=prefix, tags=["qa-visual"])
+    router = APIRouter(
+        prefix=prefix,
+        tags=["qa-visual"],
+        dependencies=list(dependencies) if dependencies else [],
+    )
     _analyzer = analyzer
 
     def get_analyzer() -> QAVisualAnalyzer:
@@ -56,29 +91,55 @@ def create_qa_visual_router(
 
     @router.post("/analyze", response_model=AnalyzeResponse)
     async def analyze_screenshot(
+        request: Request,
         screenshot: UploadFile = File(..., description="PNG screenshot to analyze"),
-        target: str = Form(..., description="Target name (page/feature identifier)"),
+        target: str = Form(
+            ..., max_length=255, description="Target name (page/feature identifier)"
+        ),
     ) -> AnalyzeResponse:
         """Analyze one screenshot with the vision model and store the report."""
-        image_bytes = await screenshot.read()
+        # S-2a: reject oversized uploads before reading the body.
+        content_length = request.headers.get("content-length", "")
+        if content_length.isdigit() and int(content_length) > (
+            MAX_SCREENSHOT_BYTES + MULTIPART_OVERHEAD_ALLOWANCE
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=f"Screenshot exceeds {MAX_SCREENSHOT_BYTES // (1024 * 1024)} MB",
+            )
+        # S-2c: only PNG screenshots are accepted (no paid API calls on junk).
+        if screenshot.content_type != "image/png":
+            raise HTTPException(
+                status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                detail="Screenshot must be image/png",
+            )
+        image_bytes = await _read_capped(screenshot)
         if not image_bytes:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail="Empty screenshot upload",
             )
-        if len(image_bytes) > MAX_SCREENSHOT_BYTES:
+        if not image_bytes.startswith(PNG_MAGIC_BYTES):
             raise HTTPException(
-                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                detail=f"Screenshot exceeds {MAX_SCREENSHOT_BYTES // (1024 * 1024)} MB",
+                status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                detail="Screenshot is not a valid PNG",
             )
         try:
             response = await get_analyzer().analyze(image_bytes, target=target)
         except QAVisualAnalysisError as exc:
-            detail = str(exc)
+            # S-3 (CWE-209): full detail goes to server logs only; the HTTP
+            # client gets a generic message.
             excerpt = (exc.raw_content or "")[:200]
-            if excerpt:
-                detail = f"{detail}. Raw output excerpt: {excerpt}"
-            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=detail) from exc
+            logger.error(
+                "QA Visual analysis failed (target=%s): %s%s",
+                target,
+                exc,
+                f" | raw output excerpt: {excerpt}" if excerpt else "",
+            )
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Vision gateway error; see server logs",
+            ) from exc
         return response
 
     @router.get("/reports")

--- a/src/infrastructure/qa_visual/gateway_client.py
+++ b/src/infrastructure/qa_visual/gateway_client.py
@@ -106,7 +106,10 @@ class VisionGatewayClient:
 
         latency_s = time.monotonic() - started
         if response.status_code != 200:
-            raise VisionGatewayError(f"Gateway HTTP {response.status_code}: {response.text[:200]}")
+            # S-3 (CWE-209): upstream body stays in server logs only, never
+            # in the exception message that could reach an HTTP client.
+            logger.error("Gateway HTTP %s: %s", response.status_code, response.text[:200])
+            raise VisionGatewayError(f"Gateway HTTP {response.status_code}")
 
         try:
             body = response.json()

--- a/tests/unit/infrastructure/test_qa_visual_endpoint.py
+++ b/tests/unit/infrastructure/test_qa_visual_endpoint.py
@@ -143,13 +143,30 @@ class TestAnalyzeEndpoint:
         analyzer.analyze.assert_not_awaited()
 
     def test_post_analyze_target_too_long_rejected(self, client):
-        """S-5: target longer than 255 chars is rejected (422), no 500."""
+        """S-5R: target longer than 200 chars is rejected (422), no 500."""
         response = client.post(
             "/api/v1/qa-visual/analyze",
             files={"screenshot": ("page.png", io.BytesIO(PNG_BYTES), "image/png")},
-            data={"target": "x" * 256},
+            data={"target": "x" * 201},
         )
         assert response.status_code == 422
+
+    def test_post_analyze_target_at_limit_accepted(self, client, analyzer):
+        """S-5R: 200-char target passes Form validation.
+
+        Storage derives the filename as target + 29 bytes of suffix, so the
+        Form limit must stay under the 255-byte filesystem name cap
+        (200 + 29 = 229 < 255). Targets of 201+ chars would pass a 255 Form
+        limit and then explode with OSError Errno 36 on save.
+        """
+        target = "x" * 200
+        analyzer.analyze.return_value = make_response(report_id="limit-rep", target=target)
+        response = client.post(
+            "/api/v1/qa-visual/analyze",
+            files={"screenshot": ("page.png", io.BytesIO(PNG_BYTES), "image/png")},
+            data={"target": target},
+        )
+        assert response.status_code == 200
 
     def test_post_analyze_requires_target(self, client):
         response = client.post(

--- a/tests/unit/infrastructure/test_qa_visual_endpoint.py
+++ b/tests/unit/infrastructure/test_qa_visual_endpoint.py
@@ -1,7 +1,6 @@
 """Unit tests for the QA Visual API router."""
 
 import io
-import json
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -110,6 +109,48 @@ class TestAnalyzeEndpoint:
         )
         assert response.status_code == 413
 
+    def test_post_analyze_content_length_precheck_rejects_early(self, client):
+        """S-2a: Content-Length far above the cap is rejected before reading."""
+        from src.infrastructure.qa_visual.endpoint import MAX_SCREENSHOT_BYTES
+
+        huge = b"x" * (MAX_SCREENSHOT_BYTES + 2 * 1024 * 1024)
+        response = client.post(
+            "/api/v1/qa-visual/analyze",
+            files={"screenshot": ("page.png", io.BytesIO(huge), "image/png")},
+            data={"target": "amc"},
+        )
+        assert response.status_code == 413
+        assert "exceeds" in response.json()["detail"].lower()
+
+    def test_post_analyze_rejects_non_png_content_type(self, client, analyzer):
+        """S-2c: uploads that are not image/png get 415, no paid API call."""
+        response = client.post(
+            "/api/v1/qa-visual/analyze",
+            files={"screenshot": ("page.jpg", io.BytesIO(PNG_BYTES), "image/jpeg")},
+            data={"target": "amc"},
+        )
+        assert response.status_code == 415
+        analyzer.analyze.assert_not_awaited()
+
+    def test_post_analyze_rejects_non_png_magic_bytes(self, client, analyzer):
+        """S-2c: image/png content-type but no PNG signature is rejected."""
+        response = client.post(
+            "/api/v1/qa-visual/analyze",
+            files={"screenshot": ("page.png", io.BytesIO(b"JFIFnotapng"), "image/png")},
+            data={"target": "amc"},
+        )
+        assert response.status_code == 415
+        analyzer.analyze.assert_not_awaited()
+
+    def test_post_analyze_target_too_long_rejected(self, client):
+        """S-5: target longer than 255 chars is rejected (422), no 500."""
+        response = client.post(
+            "/api/v1/qa-visual/analyze",
+            files={"screenshot": ("page.png", io.BytesIO(PNG_BYTES), "image/png")},
+            data={"target": "x" * 256},
+        )
+        assert response.status_code == 422
+
     def test_post_analyze_requires_target(self, client):
         response = client.post(
             "/api/v1/qa-visual/analyze",
@@ -117,7 +158,8 @@ class TestAnalyzeEndpoint:
         )
         assert response.status_code == 422
 
-    def test_post_analyze_analysis_error_returns_502(self, client, analyzer):
+    def test_post_analyze_analysis_error_returns_generic_502(self, client, analyzer):
+        """S-3: upstream gateway detail must NOT reach the HTTP client."""
         analyzer.analyze.side_effect = QAVisualAnalysisError(
             "Vision gateway failed: Gateway HTTP 503: down"
         )
@@ -127,9 +169,12 @@ class TestAnalyzeEndpoint:
             data={"target": "amc"},
         )
         assert response.status_code == 502
-        assert "503" in response.json()["detail"]
+        detail = response.json()["detail"]
+        assert "503" not in detail
+        assert "down" not in detail
 
-    def test_post_analyze_parse_error_reports_raw_excerpt(self, client, analyzer):
+    def test_post_analyze_parse_error_does_not_leak_raw_output(self, client, analyzer):
+        """S-3: raw model output excerpt must NOT reach the HTTP client."""
         analyzer.analyze.side_effect = QAVisualAnalysisError(
             "Model output could not be parsed into the QA contract",
             raw_content="garbage output",
@@ -140,7 +185,22 @@ class TestAnalyzeEndpoint:
             data={"target": "amc"},
         )
         assert response.status_code == 502
-        assert "garbage" in response.json()["detail"]
+        assert "garbage" not in response.json()["detail"]
+
+    def test_post_analyze_error_detail_logged_server_side(self, client, analyzer, caplog):
+        """S-3: full detail goes to server logs, not to the client."""
+        analyzer.analyze.side_effect = QAVisualAnalysisError(
+            "Vision gateway failed: Gateway HTTP 503: down",
+            raw_content="secret model output",
+        )
+        with caplog.at_level("ERROR", logger="src.infrastructure.qa_visual.endpoint"):
+            client.post(
+                "/api/v1/qa-visual/analyze",
+                files={"screenshot": ("page.png", io.BytesIO(PNG_BYTES), "image/png")},
+                data={"target": "amc"},
+            )
+        assert any("503" in r.message for r in caplog.records)
+        assert any("secret model output" in r.message for r in caplog.records)
 
 
 class TestReportsEndpoints:
@@ -197,3 +257,51 @@ class TestBaselinesEndpoint:
     def test_get_baseline_not_found(self, client):
         response = client.get("/api/v1/qa-visual/baselines/nope")
         assert response.status_code == 404
+
+
+class TestRouterDependencies:
+    """S-1 (Fase C): the factory must accept injectable router dependencies."""
+
+    def _protected_client(self, analyzer):
+        from fastapi import Depends, HTTPException
+
+        def deny_all() -> None:
+            raise HTTPException(status_code=401, detail="Not authenticated")
+
+        app = FastAPI()
+        app.include_router(
+            create_qa_visual_router(analyzer=analyzer, dependencies=[Depends(deny_all)])
+        )
+        return TestClient(app)
+
+    def test_dependencies_apply_to_all_five_endpoints(self, analyzer):
+        client = self._protected_client(analyzer)
+        get_paths = [
+            "/api/v1/qa-visual/reports",
+            "/api/v1/qa-visual/reports/rep-001",
+            "/api/v1/qa-visual/trends",
+            "/api/v1/qa-visual/baselines/amc",
+        ]
+        for path in get_paths:
+            assert client.get(path).status_code == 401, path
+        response = client.post(
+            "/api/v1/qa-visual/analyze",
+            files={"screenshot": ("page.png", io.BytesIO(PNG_BYTES), "image/png")},
+            data={"target": "amc"},
+        )
+        assert response.status_code == 401
+
+    def test_dependencies_run_before_analyzer(self, analyzer):
+        client = self._protected_client(analyzer)
+        client.post(
+            "/api/v1/qa-visual/analyze",
+            files={"screenshot": ("page.png", io.BytesIO(PNG_BYTES), "image/png")},
+            data={"target": "amc"},
+        )
+        analyzer.analyze.assert_not_awaited()
+
+    def test_no_dependencies_backward_compatible(self, analyzer):
+        app = FastAPI()
+        app.include_router(create_qa_visual_router(analyzer=analyzer))
+        client = TestClient(app)
+        assert client.get("/api/v1/qa-visual/reports").status_code == 200

--- a/tests/unit/infrastructure/test_qa_visual_gateway_client.py
+++ b/tests/unit/infrastructure/test_qa_visual_gateway_client.py
@@ -201,6 +201,21 @@ class TestResponseHandling:
                 await client.analyze_image(b"png")
 
     @pytest.mark.asyncio
+    async def test_http_error_detail_not_in_exception_but_logged(self, caplog):
+        """S-3: upstream body goes to logs, never into the exception message."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="internal stack trace detail")
+
+        async with make_client(handler) as client:
+            with caplog.at_level("ERROR", logger="src.infrastructure.qa_visual.gateway_client"):
+                with pytest.raises(VisionGatewayError) as exc_info:
+                    await client.analyze_image(b"png")
+
+        assert "internal stack trace detail" not in str(exc_info.value)
+        assert any("internal stack trace detail" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
     async def test_timeout_raises(self):
         def handler(request: httpx.Request) -> httpx.Response:
             raise httpx.ConnectTimeout("timed out")

--- a/tests/unit/infrastructure/test_qa_visual_vendor_parity.py
+++ b/tests/unit/infrastructure/test_qa_visual_vendor_parity.py
@@ -1,0 +1,49 @@
+"""Vendor parity guard: dashboard/backend copy must match the repo-level module.
+
+The dashboard ships a vendored copy of ``src/infrastructure/qa_visual`` under
+``dashboard/backend/src/infrastructure/qa_visual`` (same pattern as the cache
+module) because the Docker build context only includes ``dashboard/backend``.
+These two copies WILL drift silently unless a test fails loudly. If a file
+changes on either side, re-copy the module:
+
+    cp src/infrastructure/qa_visual/*.py dashboard/backend/src/infrastructure/qa_visual/
+
+Skipped automatically when the vendored copy is absent (e.g. slim deploys that
+only run the repo-level suite).
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SOURCE_DIR = REPO_ROOT / "src" / "infrastructure" / "qa_visual"
+VENDOR_DIR = REPO_ROOT / "dashboard" / "backend" / "src" / "infrastructure" / "qa_visual"
+
+pytestmark = pytest.mark.skipif(
+    not VENDOR_DIR.is_dir(), reason="vendored qa_visual copy not present"
+)
+
+
+def _py_files(directory: Path) -> dict[str, str]:
+    return {p.name: p.read_text() for p in sorted(directory.glob("*.py"))}
+
+
+def test_vendored_copy_exists():
+    assert VENDOR_DIR.is_dir(), "dashboard vendored qa_visual module is missing"
+    assert (VENDOR_DIR / "__init__.py").is_file()
+
+
+def test_vendored_copy_matches_source_file_by_file():
+    source = _py_files(SOURCE_DIR)
+    vendored = _py_files(VENDOR_DIR)
+    assert set(source) == set(vendored), (
+        f"file sets differ: only in source={set(source) - set(vendored)}, "
+        f"only in vendored={set(vendored) - set(source)}"
+    )
+    drifted = [name for name, content in source.items() if vendored[name] != content]
+    assert not drifted, (
+        f"vendored qa_visual copy drifted from src/ in: {drifted}. "
+        "Re-copy with: cp src/infrastructure/qa_visual/*.py "
+        "dashboard/backend/src/infrastructure/qa_visual/"
+    )


### PR DESCRIPTION
## Summary

Fase C (card 0ddedd75): mount the QA Visual router in the dashboard behind JWT auth and apply the upload/error hardening required by the Fase B security audit (PR #104 findings S-1..S-7).

## Changes

### Hardening (src/infrastructure/qa_visual)
- **S-1 (HIGH)**: `create_qa_visual_router(dependencies=None)` accepts injectable router-level dependencies; mounted in the dashboard with `dependencies=[Depends(get_current_user)]`. Backward compatible — the module stays decoupled from any auth service.
- **S-2 (MEDIUM)**: `POST /analyze` pre-checks `Content-Length` (with 64KB multipart overhead allowance), reads in 64KB chunks capped at 10MB (oversized uploads never fully loaded into memory), validates `image/png` content-type AND PNG magic bytes (415) before any paid gateway call.
- **S-3 (LOW, CWE-209)**: 502s return a generic message; upstream gateway body and raw model output excerpts go to server logs only (endpoint + gateway_client).
- **S-5 (LOW)**: `target` capped at 255 chars (422 instead of OSError 500).

### Dashboard wiring
- Module vendored at `dashboard/backend/src/infrastructure/qa_visual/` (same pattern as cache) because the Docker build context only ships `dashboard/backend` — the repo-level `src/` tree is unavailable at runtime.
- `main.py` mounts the router with auth: all 5 endpoints require a valid JWT.
- `tests/unit/infrastructure/test_qa_visual_vendor_parity.py` fails loudly on drift between the two copies.

### Misc
- **S-7**: `reports/qa-visual/` gitignored.
- **S-4**: data-handling policy documented in `docs/qa-visual.md` (screenshot egress to external gateway, synthetic-data-only policy, GDPR Art. 32 note).

## Tests

- Root unit suite: **698 passed, 10 skipped** (includes the 114 Fase B tests — unchanged — plus 11 new).
- Root qa_visual module coverage: **96%** (endpoint.py 99%).
- Dashboard (`tests/unit` + wiring): **169 passed + 10 wiring tests**, zero regressions.
- Wiring coverage: **endpoint.py vendored 86%** via wiring tests; all five endpoints verified 403 (no credentials) and 401 (malformed token) against the real `main.app`; authenticated happy paths with injected fake analyzer.
- Lint: black clean; the only new ruff/isort findings match the file's pre-existing Fase B idiom (main already carries 13 non-blocking findings; CI lint is `continue-on-error`).

## Constraints preserved

Thinking disabled always, max_tokens >= 4000 guard, browser UA on gateway calls, model via `QA_VISUAL_MODEL`, pricing pin 2026-08-22 — untouched.

## Known issues / notes for reviewers

- The vendored copy is a deliberate second source of truth; the parity test is the drift guard (re-copy command in its docstring and in docs/qa-visual.md).
- Reports listing is not tenant-scoped (single-tenant deployment assumption); flagged by the audit as a future item if the product goes multi-tenant.
- No merge from this side — pipeline Reviewer -> Security -> QA -> Alfred Review to follow.