### PR TITLE
fix(security): rate-limit fail-open hardening — metric, degraded header, configurable fail-closed (OBS-1)

### DIFF
--- a/dashboard/backend/middleware/rate_limit.py
+++ b/dashboard/backend/middleware/rate_limit.py
@@ -8,17 +8,27 @@ Implements granular rate limiting:
 - Redis-backed for distributed rate limiting
 """
 
+import os
 import time
 from typing import Optional, Callable
 from fastapi import Request, Response, HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 import structlog
+from prometheus_client import Counter
 
 from core.rate_limit_config import get_rate_limit, get_burst_limit, get_endpoint_limit
 from services.cache_service import get_redis_client
 
 logger = structlog.get_logger()
+
+# Backing-store (redis) failures inside the rate limiter are never silent:
+# every failure increments this counter (exposed via /metrics, alertable).
+RATE_LIMIT_BACKEND_FAILURES = Counter(
+    "rate_limit_backend_failures",
+    "Rate limit checks that failed on the backing store (e.g. redis errors)",
+    ["fail_mode"],
+)
 
 
 class RateLimiter:
@@ -32,15 +42,25 @@ class RateLimiter:
     - Sliding window for accurate rate limiting
     """
     
-    def __init__(self, redis_client=None):
+    def __init__(self, redis_client=None, fail_mode: Optional[str] = None):
         """
         Initialize rate limiter
         
         Args:
             redis_client: Redis client (optional, will use default if not provided)
+            fail_mode: Behavior on backing-store failure ("open"|"closed").
+                Defaults to env RATE_LIMIT_FAIL_MODE, else "open".
+        Valid fail modes (env RATE_LIMIT_FAIL_MODE):
+        - "open" (default): allow requests if the backing store fails, but
+          mark the response as degraded (header + metric + log event).
+        - "closed": deny requests with 503 while the backing store is down.
         """
         self.redis = redis_client or get_redis_client()
         self.prefix = "ratelimit:"
+        self.fail_mode = (fail_mode or os.getenv("RATE_LIMIT_FAIL_MODE", "open")).strip().lower()
+        if self.fail_mode not in ("open", "closed"):
+            logger.warning("Invalid RATE_LIMIT_FAIL_MODE, falling back to open", value=self.fail_mode)
+            self.fail_mode = "open"
     
     async def is_allowed(
         self,
@@ -74,6 +94,10 @@ class RateLimiter:
                 endpoint_limit,
                 window=60  # 1 minute
             )
+            if info.get("degraded"):
+                # Backing store down: short-circuit so each request produces
+                # exactly one failure event, not one per limit bucket.
+                return is_allowed, info
             if not is_allowed:
                 return False, info
         
@@ -84,6 +108,8 @@ class RateLimiter:
             burst_limit,
             window=60  # 1 minute
         )
+        if burst_info.get("degraded"):
+            return is_allowed, burst_info
         if not is_allowed:
             return False, burst_info
         
@@ -94,6 +120,8 @@ class RateLimiter:
             hourly_limit,
             window=3600  # 1 hour
         )
+        if hourly_info.get("degraded"):
+            return is_allowed, hourly_info
         if not is_allowed:
             return False, hourly_info
         
@@ -150,9 +178,30 @@ class RateLimiter:
             return is_allowed, info
             
         except Exception as e:
-            logger.error("Rate limit check failed", error=str(e), key=key)
-            # Fail open - allow request if Redis fails
-            return True, {"limit": limit, "remaining": limit, "error": str(e)}
+            # Backing-store failure — never silent: distinct log event + metric.
+            # Details stay server-side (no error strings in responses).
+            try:
+                RATE_LIMIT_BACKEND_FAILURES.labels(fail_mode=self.fail_mode).inc()
+            except Exception:
+                pass
+            logger.error(
+                "rate_limit_backend_failure",
+                fail_mode=self.fail_mode,
+                error_type=type(e).__name__,
+                error=str(e),
+                key=key,
+            )
+            info = {
+                "limit": limit,
+                "remaining": limit,
+                "reset": int(current_time + window),
+                "window": window,
+                "degraded": True,
+            }
+            if self.fail_mode == "closed":
+                return False, info
+            # Fail open (default): allow request but flag degradation
+            return True, info
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
@@ -197,14 +246,28 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             endpoint=request.url.path
         )
         
+        degraded = bool(rate_info.get("degraded"))
+        
         # Add rate limit headers
         headers = {
             "X-RateLimit-Limit": str(rate_info.get("limit", 0)),
             "X-RateLimit-Remaining": str(rate_info.get("remaining", 0)),
             "X-RateLimit-Reset": str(rate_info.get("reset", 0))
         }
+        if degraded:
+            # Externally visible signal that rate limiting is currently
+            # unavailable (backing store failure).
+            headers["X-RateLimit-Mode"] = "degraded"
         
         if not is_allowed:
+            if degraded:
+                # RATE_LIMIT_FAIL_MODE=closed: backing store down. This is a
+                # service degradation, NOT a client abuse signal — 503, not 429.
+                return JSONResponse(
+                    status_code=503,
+                    content={"detail": "Service temporarily degraded, please retry later"},
+                    headers={**headers, "Retry-After": "30"}
+                )
             # Rate limit exceeded
             logger.warning(
                 "Rate limit exceeded",
@@ -276,6 +339,11 @@ async def check_rate_limit(request: Request, plan: str = "free"):
     )
     
     if not is_allowed:
+        if rate_info.get("degraded"):
+            raise HTTPException(
+                status_code=503,
+                detail="Service temporarily degraded, please retry later"
+            )
         raise HTTPException(
             status_code=429,
             detail={

--- a/dashboard/backend/tests/middleware/test_rate_limit.py
+++ b/dashboard/backend/tests/middleware/test_rate_limit.py
@@ -180,7 +180,7 @@ class TestRateLimiter:
     
     @pytest.mark.asyncio
     async def test_redis_failure_fails_open(self, rate_limiter, mock_redis):
-        """Should allow request if Redis fails"""
+        """Should allow request if Redis fails (default open mode), flagged degraded"""
         mock_redis.zcard = AsyncMock(side_effect=Exception("Redis error"))
         
         is_allowed, info = await rate_limiter.is_allowed(
@@ -190,7 +190,102 @@ class TestRateLimiter:
         )
         
         assert is_allowed is True
-        assert "error" in info
+        assert info.get("degraded") is True
+        # Error details must stay server-side (S-3 discipline: no leakage)
+        assert "error" not in info
+
+
+class TestFailModeBehavior:
+    """Behavior on backing-store failure (card 4f9fb443, audit OBS-1)"""
+    
+    @pytest.fixture
+    def failing_redis(self):
+        redis = AsyncMock()
+        redis.zremrangebyscore = AsyncMock(side_effect=Exception("Event loop is closed"))
+        return redis
+    
+    @pytest.mark.asyncio
+    async def test_fail_open_marks_degraded(self, failing_redis):
+        """Open mode: request allowed, degraded flag set"""
+        limiter = RateLimiter(redis_client=failing_redis, fail_mode="open")
+        is_allowed, info = await limiter.is_allowed("user:1", "free", "/api/v1/test")
+        assert is_allowed is True
+        assert info.get("degraded") is True
+    
+    @pytest.mark.asyncio
+    async def test_fail_closed_denies(self, failing_redis):
+        """Closed mode: request denied, degraded flag set"""
+        limiter = RateLimiter(redis_client=failing_redis, fail_mode="closed")
+        is_allowed, info = await limiter.is_allowed("user:1", "free", "/api/v1/test")
+        assert is_allowed is False
+        assert info.get("degraded") is True
+    
+    @pytest.mark.asyncio
+    async def test_backend_failure_short_circuits_single_event(self, failing_redis):
+        """One backing-store failure per request: first redis error short-circuits"""
+        limiter = RateLimiter(redis_client=failing_redis, fail_mode="open")
+        await limiter.is_allowed("user:1", "pro", "/api/v1/auth/login")
+        # Endpoint limit bucket is the first check → exactly 1 redis call, not 3
+        assert failing_redis.zremrangebyscore.await_count == 1
+    
+    @pytest.mark.asyncio
+    async def test_failure_metric_incremented(self, failing_redis):
+        """Every backing-store failure increments the Prometheus counter"""
+        from prometheus_client import REGISTRY
+        
+        def sample(mode):
+            return REGISTRY.get_sample_value(
+                "rate_limit_backend_failures_total", {"fail_mode": mode}
+            ) or 0
+        
+        before_open = sample("open")
+        before_closed = sample("closed")
+        
+        await RateLimiter(redis_client=failing_redis, fail_mode="open").is_allowed(
+            "user:1", "free", "/api/v1/test")
+        await RateLimiter(redis_client=failing_redis, fail_mode="closed").is_allowed(
+            "user:1", "free", "/api/v1/test")
+        
+        assert sample("open") == before_open + 1
+        assert sample("closed") == before_closed + 1
+    
+    def test_invalid_fail_mode_falls_back_open(self, failing_redis):
+        """Unknown RATE_LIMIT_FAIL_MODE value falls back to open"""
+        limiter = RateLimiter(redis_client=failing_redis, fail_mode="yolo")
+        assert limiter.fail_mode == "open"
+    
+    def test_middleware_open_mode_200_with_degraded_header(self, failing_redis):
+        """Middleware: open mode keeps serving but exposes X-RateLimit-Mode: degraded"""
+        app = FastAPI()
+        app.add_middleware(
+            RateLimitMiddleware,
+            rate_limiter=RateLimiter(redis_client=failing_redis, fail_mode="open"),
+        )
+        
+        @app.get("/test")
+        async def test_endpoint():
+            return {"status": "ok"}
+        
+        response = TestClient(app).get("/test")
+        assert response.status_code == 200
+        assert response.headers.get("X-RateLimit-Mode") == "degraded"
+    
+    def test_middleware_closed_mode_503_no_leak(self, failing_redis):
+        """Middleware: closed mode returns 503 + Retry-After, no backend error leaked"""
+        app = FastAPI()
+        app.add_middleware(
+            RateLimitMiddleware,
+            rate_limiter=RateLimiter(redis_client=failing_redis, fail_mode="closed"),
+        )
+        
+        @app.get("/test")
+        async def test_endpoint():
+            return {"status": "ok"}
+        
+        response = TestClient(app).get("/test")
+        assert response.status_code == 503
+        assert response.headers.get("Retry-After") == "30"
+        assert "Event loop is closed" not in response.text
 
 
 class TestRateLimitMiddleware:


### PR DESCRIPTION
## Summary

Security audit **OBS-1** (`qa-visual-fase-c-pr105-2026-08-23.md`): `RateLimitMiddleware` failed **OPEN silently** — if redis fails (test evidence: `Rate limit check failed error='Event loop is closed'`), requests proceeded with **no rate limit and no signal**. Applies app-wide (preexisting, not from PR #105). Relevant for cost abuse of paid endpoints (`qa-visual analyze`) once enabled.

Card: `4f9fb443` [P3].

## Changes

**Failures are now never silent:**
- **Prometheus counter** `rate_limit_backend_failures_total{fail_mode}` — incremented on every backing-store failure, exposed via the existing `/metrics` mount (alertable: `increase(rate_limit_backend_failures_total[5m]) > 0`).
- **Distinct log event** `rate_limit_backend_failure` (error level, structlog) with `fail_mode`, `error_type`, key — replaces the generic message.
- **`X-RateLimit-Mode: degraded`** response header in open mode — externally visible.

**Configurable failure mode** — env `RATE_LIMIT_FAIL_MODE=open|closed` (default **open**, backward compatible):
- `open`: allow (as today) but flagged everywhere as above.
- `closed`: deny with **503 + Retry-After** while the backing store is down. A redis outage is service degradation, not client abuse — hence 503, not 429.
- Invalid values fall back to `open` with a warning.
- `check_rate_limit` dependency updated consistently (503 on degraded denial).

**Hygiene:**
- Short-circuit on first backing-store failure → exactly **one** metric/log event per request (not 3, one per limit bucket).
- Backend error strings stay **server-side only** — no leakage in responses/headers (S-3 discipline).

## Testing

- 8 new tests (`TestFailModeBehavior`): open marks degraded, closed denies, single-event short-circuit, metric increment per mode (via `REGISTRY.get_sample_value`), invalid mode fallback, middleware 200+header (open), middleware 503+Retry-After+no-leak (closed).
- Updated `test_redis_failure_fails_open`: asserts `degraded` marker + absence of `error` in info.
- `tests/middleware/test_rate_limit.py` **27/27**, `tests/middleware/ + test_qa_visual_wiring.py` **50/50** — no regressions.

## Deployment notes

- Default behavior unchanged (fail open) — zero-config safe merge. Set `RATE_LIMIT_FAIL_MODE=closed` at deploy time if strict enforcement is desired (trade-off: redis outage → dashboard 503s).
- Follow-up (out of scope): alertmanager rule on the new counter.
