### PR TITLE
fix: rate-limit /metrics skip trailing-slash (PrometheusTargetMissing flapping) + externalize alertmanager Telegram token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ playwright-report/
 
 # QA Visual runtime artifacts (reports + hook screenshots)
 reports/qa-visual/
+dashboard/monitoring/alertmanager/.secrets/

--- a/dashboard/backend/middleware/rate_limit.py
+++ b/dashboard/backend/middleware/rate_limit.py
@@ -167,7 +167,11 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self.rate_limiter = rate_limiter or RateLimiter()
         
-        # Paths to skip rate limiting
+        # Paths to skip rate limiting.
+        # NOTE (card f90a8079): FastAPI redirect_slashes 307-redirects /metrics to
+        # /metrics/, so this middleware sees the TRAILING-SLASH variant. Compare
+        # with trailing slashes stripped on BOTH sides; the request path itself
+        # is never mutated.
         self.skip_paths = {
             "/metrics",
             "/health",
@@ -176,12 +180,13 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             "/redoc",
             "/openapi.json"
         }
-    
+        self._skip_paths_norm = {p.rstrip("/") for p in self.skip_paths}
+
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         """Process request with rate limiting"""
-        
-        # Skip rate limiting for certain paths
-        if request.url.path in self.skip_paths:
+
+        # Skip rate limiting for certain paths (trailing-slash tolerant)
+        if request.url.path.rstrip("/") in self._skip_paths_norm:
             return await call_next(request)
         
         # Get identifier (user_id or IP)

--- a/dashboard/backend/tests/middleware/test_rate_limit.py
+++ b/dashboard/backend/tests/middleware/test_rate_limit.py
@@ -13,7 +13,7 @@ import pytest
 pytest.importorskip('fastapi')
 pytest.importorskip('redis')
 pytest.importorskip('asyncpg')
-from unittest.mock import Mock, AsyncMock, patch
+from unittest.mock import Mock, AsyncMock, MagicMock, patch
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 import time
@@ -273,6 +273,73 @@ class TestIntegration:
                 assert is_allowed is True
             else:
                 assert is_allowed is False
+
+
+class TestSkipPathTrailingSlash:
+    """card f90a8079: FastAPI redirect_slashes 307-redirects /metrics -> /metrics/,
+    so the middleware sees the TRAILING-SLASH variant. The skip check must
+    tolerate trailing slashes on both sides (comparison-only; the request path
+    is never mutated)."""
+
+    @staticmethod
+    def _make_middleware(rate_limiter=None):
+        # rate_limiter injection avoids any Redis dependency in these tests
+        return RateLimitMiddleware(app=Mock(), rate_limiter=rate_limiter or Mock())
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("path", [
+        "/metrics", "/metrics/",
+        "/health", "/health/",
+        "/docs", "/docs/",
+        "/openapi.json", "/openapi.json/",
+    ])
+    async def test_dispatch_skips_without_ratelimit_call(self, path):
+        """Skipped paths (with/without trailing slash) bypass the limiter entirely"""
+        mw = self._make_middleware()
+        request = Mock()
+        request.url.path = path
+        sentinel = MagicMock()
+        call_next = AsyncMock(return_value=sentinel)
+
+        response = await mw.dispatch(request, call_next)
+
+        assert response is sentinel
+        call_next.assert_awaited_once_with(request)
+        mw.rate_limiter.is_allowed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_non_skip_path_calls_limiter(self):
+        """Control: non-skipped paths still go through the limiter"""
+        limiter = Mock()
+        limiter.is_allowed = AsyncMock(return_value=(
+            True, {"limit": 100, "remaining": 99, "reset": 0}
+        ))
+        mw = self._make_middleware(rate_limiter=limiter)
+        request = MagicMock()
+        request.url.path = "/api/v1/test"
+        request.headers.get.return_value = None
+        request.client.host = "127.0.0.1"
+        call_next = AsyncMock(return_value=MagicMock())
+
+        await mw.dispatch(request, call_next)
+
+        limiter.is_allowed.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_lookalike_paths_not_skipped(self):
+        """Lookalike paths must NOT be skipped (normalization must not over-match)"""
+        limiter = Mock()
+        limiter.is_allowed = AsyncMock(return_value=(
+            True, {"limit": 100, "remaining": 99, "reset": 0}
+        ))
+        mw = self._make_middleware(rate_limiter=limiter)
+        for path in ("/api/v1/metrics", "/metricsx", "/v1/health"):
+            request = MagicMock()
+            request.url.path = path
+            request.headers.get.return_value = None
+            request.client.host = "127.0.0.1"
+            await mw.dispatch(request, AsyncMock(return_value=MagicMock()))
+        assert limiter.is_allowed.await_count == 3
 
 
 # Run tests

--- a/dashboard/monitoring/alertmanager/alertmanager.yml
+++ b/dashboard/monitoring/alertmanager/alertmanager.yml
@@ -14,7 +14,7 @@ route:
       group_wait: 0s
       repeat_interval: 5m
       continue: true
-    
+
     - match:
         severity: warning
       receiver: 'warning-alerts'
@@ -23,21 +23,10 @@ route:
 
 receivers:
   - name: 'default-receiver'
-    slack_configs:
-      - api_url: '${SLACK_WEBHOOK_URL:-http://localhost:3000}'
-        channel: '#alerts'
-        title: 'QA-Framework Alert'
-        text: |
-          {{ range .Alerts }}
-          *Alert:* {{ .Annotations.summary }}
-          *Description:* {{ .Annotations.description }}
-          *Severity:* {{ .Labels.severity }}
-          *Instance:* {{ .Labels.instance }}
-          {{ end }}
     telegram_configs:
-      - bot_token: '${TELEGRAM_BOT_TOKEN:-}'
-        api_url: '${TELEGRAM_API_URL:-https://api.telegram.org}'
-        chat_id: '${TELEGRAM_CHAT_ID:-}'
+      - bot_token_file: /run/secrets/alertmanager_telegram_token
+        api_url: 'https://api.telegram.org'
+        chat_id: 346997361
         parse_mode: 'HTML'
         message: |
           🚨 <b>QA-FRAMEWORK ALERT</b>
@@ -51,38 +40,10 @@ receivers:
           {{ end }}
 
   - name: 'critical-alerts'
-    slack_configs:
-      - api_url: '${SLACK_WEBHOOK_URL:-http://localhost:3000}'
-        channel: '#critical-alerts'
-        title: '🚨 CRITICAL: QA-Framework Alert'
-        text: |
-          {{ range .Alerts }}
-          *CRITICAL ALERT:* {{ .Annotations.summary }}
-          *Description:* {{ .Annotations.description }}
-          *Instance:* {{ .Labels.instance }}
-          *Time:* {{ .StartsAt.Format "2006-01-02 15:04:05" }}
-          {{ end }}
-    email_configs:
-      - to: '${ALERT_EMAIL:-admin@example.com}'
-        from: 'alertmanager@qa-framework.local'
-        smarthost: '${SMTP_HOST:-localhost:587}'
-        auth_username: '${SMTP_USER:-}'
-        auth_password: '${SMTP_PASSWORD:-}'
-        headers:
-          Subject: 'CRITICAL: QA-Framework Alert'
-        html: |
-          <h2>Critical Alert from QA-Framework Dashboard</h2>
-          {{ range .Alerts }}
-          <p><strong>Alert:</strong> {{ .Annotations.summary }}</p>
-          <p><strong>Description:</strong> {{ .Annotations.description }}</p>
-          <p><strong>Severity:</strong> {{ .Labels.severity }}</p>
-          <p><strong>Instance:</strong> {{ .Labels.instance }}</p>
-          <hr>
-          {{ end }}
     telegram_configs:
-      - bot_token: '${TELEGRAM_BOT_TOKEN:-}'
-        api_url: '${TELEGRAM_API_URL:-https://api.telegram.org}'
-        chat_id: '${TELEGRAM_CHAT_ID:-}'
+      - bot_token_file: /run/secrets/alertmanager_telegram_token
+        api_url: 'https://api.telegram.org'
+        chat_id: 346997361
         parse_mode: 'HTML'
         message: |
           🔴 <b>CRITICAL - QA-FRAMEWORK</b>
@@ -95,19 +56,10 @@ receivers:
           {{ end }}
 
   - name: 'warning-alerts'
-    slack_configs:
-      - api_url: '${SLACK_WEBHOOK_URL:-http://localhost:3000}'
-        channel: '#warnings'
-        title: '⚠️ Warning: QA-Framework'
-        text: |
-          {{ range .Alerts }}
-          *Warning:* {{ .Annotations.summary }}
-          *Description:* {{ .Annotations.description }}
-          {{ end }}
     telegram_configs:
-      - bot_token: '${TELEGRAM_BOT_TOKEN:-}'
-        api_url: '${TELEGRAM_API_URL:-https://api.telegram.org}'
-        chat_id: '${TELEGRAM_CHAT_ID:-}'
+      - bot_token_file: /run/secrets/alertmanager_telegram_token
+        api_url: 'https://api.telegram.org'
+        chat_id: 346997361
         parse_mode: 'HTML'
         message: |
           ⚠️ <b>WARNING - QA-FRAMEWORK</b>

--- a/dashboard/monitoring/alertmanager/telegram_token.example
+++ b/dashboard/monitoring/alertmanager/telegram_token.example
@@ -1,0 +1,3 @@
+# Copy to .secrets/telegram_token (chmod 600) and fill with the real value.
+# NEVER commit the real token.
+1234567890:AAAA-your-bot-token-here

--- a/docker-compose.unified.yml
+++ b/docker-compose.unified.yml
@@ -168,7 +168,8 @@ services:
 
   # Alertmanager
   alertmanager:
-    image: prom/alertmanager:v0.25.0
+    # v0.28.1: telegram_configs.bot_token_file requires >=0.27 (secret externalization)
+    image: prom/alertmanager:v0.28.1
     container_name: qa-framework-alertmanager
     command:
       - '--config.file=/etc/alertmanager/alertmanager.yml'
@@ -181,6 +182,8 @@ services:
     networks:
       - qa-network
     restart: unless-stopped
+    secrets:
+      - alertmanager_telegram_token
 
 # Named volumes
 volumes:
@@ -191,6 +194,11 @@ volumes:
   grafana-data:
   alertmanager-data:
   nuclei-templates:
+
+# Secrets (host-local files, NEVER committed — see .gitignore)
+secrets:
+  alertmanager_telegram_token:
+    file: ./dashboard/monitoring/alertmanager/.secrets/telegram_token
 
 # Networks
 networks:


### PR DESCRIPTION
## Root cause (card f90a8079)

`PrometheusTargetMissing` fired every 30m since 14:12 UTC 08-23 (59% scrape failures, `avg_over_time(up[3h])=0.41`):

```
Prometheus GET /metrics -> FastAPI 307 redirect (redirect_slashes) -> /metrics/
  -> RateLimitMiddleware skip check: '/metrics/' NOT in skip_paths ('/metrics')
  -> identifier ip:<prometheus>, unauthenticated -> free plan = 100 req/h
  -> 15s scrape interval = 240 req/h >> 100 -> 140 fails/h steady state
```

Math confirmed: observed 0.411 ≈ predicted 100/240 = 0.4167; backend logs show exactly 140 429s/h sustained.

## Changes

**1. `dashboard/backend/middleware/rate_limit.py`** — skip check compares `rstrip('/')` on both sides (request path NEVER mutated). Trailing-slash variants (`/metrics/`, `/health/`, `/docs/`…) now skip as designed.

**2. `alertmanager.yml` rescued + token externalized** — main's version was **unparseable** (literal `${SLACK_WEBHOOK_URL:-…}` placeholders — alertmanager does no env substitution; `amtool check-config` FAILED). Runtime has been mounting an uncommitted working-tree file (telegram-only, valid). This PR commits a valid telegram-only config with:

```yaml
bot_token_file: /run/secrets/alertmanager_telegram_token
```

**3. `docker-compose.unified.yml`** — alertmanager `v0.25.0 -> v0.28.1` (`bot_token_file` requires >=0.27) + compose secret `alertmanager_telegram_token` (file: `dashboard/monitoring/alertmanager/.secrets/telegram_token`, **gitignored**; only `telegram_token.example` committed). `docker compose config` VALID; `amtool check-config` SUCCESS on v0.28.1 (3 receivers, route, inhibit).

## Security notes (for Security review)

- `git log -S` across all branches: the real token was **NEVER committed** — it only ever lived in the uncommitted working-tree file. This PR keeps it out of git history permanently.
- Token rotation recommended anyway as defense-in-depth (it sat plaintext on disk); owner decision (Joker's bot).
- Tradeoff for Security to sign: normalizing the skip check makes `/metrics` unlimited **by design** (skip_paths intent) — it was only "rate-limited" until now by the accident of the 307 redirect. Prometheus scrapes are internal-network only.

## Tests

10 new dispatch-level cases (`TestSkipPathTrailingSlash`): skip with/without trailing slash ×4 paths (no limiter call), control non-skip path (limiter called), lookalike paths (`/api/v1/metrics`, `/metricsx`, `/v1/health`) NOT skipped. **Suite 30/30 green locally** (coverage gate N/A — single-file run).

## Deploy plan (post-merge, ops window — NOT in this PR)

1. Stage `.secrets/telegram_token` on the host (from current runtime config), chmod 600
2. `docker compose -f docker-compose.unified.yml up -d alertmanager`
3. Verify: Telegram round-trip (test alert), alertmanager UI healthy
4. Revert interim mitigation: `qa-framework-backend` `scrape_interval` 60s -> 15s (commit 759c2e6 on feat branch)

Interim mitigation already live: 60s interval (60 req/h < 100) — scrape stable 0 fails since 20:47 UTC 08-23 (Alfred-verified avg30m=1.0).