### PR TITLE
ops(compose): backend loopback rebind 8010 (R-1) + sync port bindings to deployed state (card 21856367)

### DIFF
--- a/docker-compose.unified.yml
+++ b/docker-compose.unified.yml
@@ -10,7 +10,7 @@ services:
       dockerfile: Dockerfile
     container_name: qa-framework-backend
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8010:8000"
     environment:
       - DATABASE_URL=postgresql://qa_user:qa_pass@postgres:5432/qa_dashboard
       - REDIS_HOST=redis
@@ -42,7 +42,7 @@ services:
       dockerfile: Dockerfile
     container_name: qa-framework-frontend
     ports:
-      - "3000:3000"
+      - "3010:3000"
     environment:
       - VITE_API_URL=http://localhost:8000
     depends_on:
@@ -66,8 +66,6 @@ services:
       POSTGRES_PORT: 5432
     volumes:
       - postgres-data:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
     networks:
       - qa-network
     healthcheck:
@@ -84,8 +82,6 @@ services:
     command: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy allkeys-lru
     volumes:
       - redis-data:/data
-    ports:
-      - "6379:6379"
     networks:
       - qa-network
     healthcheck:
@@ -142,7 +138,7 @@ services:
       - ./dashboard/monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-data:/prometheus
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9091:9090"
     networks:
       - qa-network
     restart: unless-stopped
@@ -159,7 +155,7 @@ services:
       - ./dashboard/monitoring/grafana/provisioning:/etc/grafana/provisioning
       - grafana-data:/var/lib/grafana
     ports:
-      - "3001:3000"
+      - "127.0.0.1:3005:3000"
     networks:
       - qa-network
     depends_on:
@@ -178,7 +174,7 @@ services:
       - ./dashboard/monitoring/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml
       - alertmanager-data:/alertmanager
     ports:
-      - "9093:9093"
+      - "127.0.0.1:9093:9093"
     networks:
       - qa-network
     restart: unless-stopped


### PR DESCRIPTION
## What

Closes security **R-1** from PR #112's security review (card 21856367): backend `qa-framework-backend` published `0.0.0.0:8010->8000` (LAN + Tailscale exposed). Only legitimate consumer is the HOST nginx (`qa.sabatech.dev /api/` → `127.0.0.1:8010`), so a loopback bind covers it. Same pattern as the SearXNG rebind (18db1be1).

## Port-sync context (why this is more than one line)

The card's AC assumed the deployed port map (`8010:8000`) was on `main` — it wasn't. The deployed stack runs from the local working tree (feat branch), while `origin/main`'s compose was stale: **deploying from main as-is would regress the approved trivy rebinds and expose postgres/redis on 0.0.0.0**. This PR therefore syncs the port blocks to the runtime-deployed, approved state:

| Service | main (before) | after (= runtime + fix) |
|---|---|---|
| backend | `8000:8000` (0.0.0.0) | **`127.0.0.1:8010:8000`** ← the R-1 fix |
| frontend | `3000:3000` | `3010:3000` (matches runtime; exposure unchanged) |
| postgres | `5432:5432` (0.0.0.0) | removed (internal-only, matches runtime) |
| redis | `6379:6379` (0.0.0.0) | removed (internal-only, matches runtime) |
| prometheus | `9090:9090` (0.0.0.0) | `127.0.0.1:9091:9090` (trivy F2, approved 706b6332) |
| grafana | `3001:3000` (0.0.0.0) | `127.0.0.1:3005:3000` (trivy F1, approved 17ab8043) |
| alertmanager | `9093:9093` (0.0.0.0) | `127.0.0.1:9093:9093` (trivy F2, approved 706b6332) |

## Scope discipline

**Ports only.** Image versions (grafana 12.4.9, prometheus v3.14.0), the exporters services and the alert rules restored in 0c8154e1 live on the unmerged monitoring commits (7af9238/a2b9319/759c2e6 on `feat/diataxis-api-ref`) — merging that branch (mixed with docs work) is a separate sequencing decision, flagged to Alfred.

## Verification

- `docker compose -f docker-compose.unified.yml config` → valid (only the pre-existing obsolete-`version` warning)
- Runtime bindings (current, pre-deploy): `docker ps` shows backend `0.0.0.0:8010->8000` — the exposure R-1 flags
- Post-deploy AC2/AC3 (`ss` loopback-only, health 200, qa.sabatech.dev/api/ 200, prometheus target up) execute in the ops window together with PR #112's alertmanager deploy — one `docker compose up -d alertmanager backend` from a main checkout covers both

## Related

- Security report: `reports/security/pr112-rate-limit-metrics-skip-2026-08-24.md` (R-1)
- Card 21856367 · PR #112 (merged 180d309) · docs follow-up #113
