### PR TITLE
fix(compose): healthcheck+loopback fixes — close runtime→main drift (3rd gen)

### DIFF
--- a/docker-compose.unified.yml
+++ b/docker-compose.unified.yml
@@ -29,7 +29,7 @@ services:
     networks:
       - qa-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.unified.yml
+++ b/docker-compose.unified.yml
@@ -29,7 +29,7 @@ services:
     networks:
       - qa-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -42,7 +42,7 @@ services:
       dockerfile: Dockerfile
     container_name: qa-framework-frontend
     ports:
-      - "3010:3000"
+      - "127.0.0.1:3010:3000"
     environment:
       - VITE_API_URL=http://localhost:8000
     depends_on:


### PR DESCRIPTION
## What

Compose fixes for QA-FRAMEWORK runtime that are live but unmerged to main:

- `2b6172b`: frontend 3010 loopback-only + healthcheck `/health` fix (card 21856367 R-1 + card 2de2d985)
- `dae609e`: backend healthcheck via python urllib (image has no curl — matches runtime feat tree)

## Why (drift — 3rd generation)

These fixes are deployed to production via the feat/diataxis-api-ref working tree but are **not on main**. Any redeploy from main would lose:

1. The healthcheck fix (backend container was using curl-based healthcheck but the image doesn't have curl → healthcheck always fails)
2. The loopback-only rebind for frontend3010 (security R-1 from PR #112 review)

This is the third time this drift pattern has surfaced (previous: feat tree uncommitted state, then partial compose merges). Merging these fixes to main closes the gap.

## Cards

- 21856367 (8010 rebind, R-1 security)
- 2de2d985 (docs+nginx, R-2 defense-in-depth)

## Verification

- Backend healthcheck: `docker exec qa-framework-backend python -c "import urllib.request; urllib.request.urlopen('http://localhost:3000/health')"` → 200
- Frontend: 127.0.0.1:3010 → 200, external access blocked
- Stack 7/7 healthy
