### PR TITLE
fix(ci): quote !cancelled() YAML tag in e2e.yml — restore workflow execution

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -60,7 +60,7 @@ jobs:
           CI: true
 
       - name: Upload test artifacts
-        if: !cancelled()
+        if: '!cancelled()'
         uses: actions/upload-artifact@v4 # v4.6.2
         with:
           name: playwright-report


### PR DESCRIPTION
## What

Quotes the `!cancelled()` YAML expression in `.github/workflows/e2e.yml`.

## Root Cause

The bare `!cancelled()` was interpreted as a YAML tag by the parser, causing a **workflow-level parse error**. Result: 0 jobs executed, 8 consecutive failures since `6a51fbb` (the PR #108 CI rot fix — layer 6 of the 7-layer CI rot).

This is a well-known GitHub Actions gotcha: YAML parsers treat `!` as a tag indicator (like `!important` in CSS). The fix is mechanical: single-quote the expression.

## Why Now

This regression was introduced in the CI rot fix (PR #108, commit 6a51fbb) and has silently broken every push/PR to main since then. The `e2e.yml` workflow is standalone from `ci-cd.yml` — the "E2E Tests" job that passed in PR #112 belongs to `ci-cd.yml`, not this file. Both are needed.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e.yml'))"` → OK
- After merge, the next push/PR to main should trigger `e2e.yml` with ≥1 job running
- The `!cancelled()` guard on the artifact upload step is preserved (ensures artifacts upload even if tests fail or are cancelled)

## Cards

- 83099ef8 (e2e.yml regression, P2 high)
