### PR TITLE
feat(accuracy-testing): eval/holdout split with sealed aggregate-only holdout (F-ACC-006)

### DIFF
--- a/docs/plans/2026-08-23-accuracy-holdout-benchmark-plan.md
+++ b/docs/plans/2026-08-23-accuracy-holdout-benchmark-plan.md
@@ -1,0 +1,147 @@
+# Plan: Holdout Benchmark Support — Accuracy Testing Module
+
+**Card:** ca3090d5-84bc-455d-a4f9-e2c62015a61b [P2]
+**Branch:** `feat/accuracy-holdout-benchmark` (base: `feat/accuracy-testing-german-ai-liability`, que contiene el módulo — aún no mergeada en `main`)
+**Date:** 2026-08-23
+**Req. IDs:** F-ACC-006 (holdout split + anti-leak)
+
+## 1. Problema
+
+Benchmarks de accuracy observables (preguntas + ground truth + resultados por ítem)
+permiten overfitting: un agente o equipo puede tunelear contra el eval set hasta
+memorizarlo (ref: Dan Luu — agente que overfitteó el benchmark hasta el holdout;
+HF: 6/11 modelos ASR memorizan tests públicos).
+
+Diferenciador del producto: "evals que no se pueden gamear".
+
+## 2. Brainstorming — 3 enfoques
+
+### Enfoque A — Dominio puro: SplitPolicy + BenchmarkSplit + HoldoutSummary (SELECCIONADO)
+
+- Split determinista por orden hash SHA-256(`salt:benchmark.id`), ratio exacto.
+- `BenchmarkSplit` serializa/repr SOLO contadores (contenido del holdout nunca sale).
+- `HoldoutEvaluationService` evalúa el holdout, agrega a `HoldoutSummary` (solo
+  métricas agregadas: count, pass_rate, average_score, hallucinations) y
+  **descarta** los resultados por ítem. Sin logging de contenido.
+- `AccuracyTestSession.holdout_summary` opcional; `to_dict()` expone solo agregados.
+
+**Pros:** cero dependencias nuevas; sigue Clean Architecture del módulo
+(dataclasses + Protocols, sin persistencia aún); la garantía anti-leak vive en el
+dominio, por lo que cualquier UI/API futura construida sobre `to_dict()` no puede
+mostrar contenido del holdout; 100% testeable.
+**Contras:** la protección es por construcción de serialización, no criptográfica.
+
+### Enfoque B — Holdout gestionado por repositorio (infra)
+
+- `IBenchmarkRepository.get_by_domain(subset="holdout")`; el holdout nunca sale
+  de la capa de persistencia salvo por una ruta sellada.
+- **Descartado:** no existe implementación de repositorio aún (solo interfaces) →
+  código especulativo (YAGNI). Complejidad de consistencia split dominio/storage.
+- Evolución natural cuando haya repositorios reales.
+
+### Enfoque C — Holdout cifrado criptográficamente
+
+- Ground truths cifrados; scoring sin revelar verdad.
+- **Descartado:** el evaluador actual necesita `ground_truth` en claro; key
+  management fuera de alcance; over-engineering para fase BETA.
+
+## 3. Diseño (Enfoque A)
+
+### 3.1 Nuevos componentes (`src/domain/accuracy_testing/`)
+
+**`splitting.py`**
+
+- `SplitPolicy` (frozen dataclass):
+  - `holdout_ratio: float = 0.2` — validado en `(0.0, 1.0)` exclusivo.
+  - `salt: str = ""` — permite splits distintos por tenant/deployment.
+  - `min_eval_size: int = 1`, `min_holdout_size: int = 1` — > 0.
+- `split_benchmarks(benchmarks, policy) -> BenchmarkSplit`:
+  - Si `len(benchmarks) < 2`: todo a eval, holdout vacío (no hay nada que ocultar).
+  - Si `>= 2`: `k = clamp(round(N * ratio), min_holdout, N - min_eval)`; si el
+    rango es vacío → `ValueError`.
+  - Orden determinista: ordenar por `(sha256(salt:id), id)`; holdout = primeros k;
+    eval = resto. Determinista entre procesos (sha256, NO `hash()` nativo que está
+    salted por proceso).
+- `BenchmarkSplit`:
+  - Invariantes en `__post_init__`: sin duplicados, eval/holdout disjuntos,
+    tamaños >= mínimos del policy.
+  - `to_dict()`: SOLO `eval_count`, `holdout_count`, `policy` (ratio/salt OMITIDO
+    en dict público para no facilitar reconstrucción; se expone `holdout_ratio`
+    numérico sin salt). Contenido: NUNCA.
+  - `__repr__` redactado: `BenchmarkSplit(eval_count=N, holdout_count=M)` —
+    anti-leak en logs accidentales.
+- `HoldoutSummary` (frozen dataclass): `holdout_count`, `pass_rate`,
+  `average_score`, `hallucination_count`, `evaluated_at`; property
+  `accuracy_level`; `to_dict()` solo agregados — sin ids, preguntas, respuestas
+  ni ground truth.
+
+**`holdout_service.py`**
+
+- `HoldoutEvaluationService(evaluator: IAccuracyEvaluator)`:
+  - `run_holdout(split, response_provider, ai_model="") -> HoldoutSummary`
+  - Itera `split.holdout_benchmarks`: `provider.get_response(b.question)` →
+    `evaluator.evaluate(b, response)` → acumula métricas → **descarta** el
+    detalle por ítem.
+  - No loguea contenido (módulo sin logging por diseño).
+  - Holdout vacío → summary con `holdout_count=0`.
+
+### 3.2 Modificaciones
+
+- `entities.py` — `AccuracyTestSession`:
+  - Nuevo campo `holdout_summary: Optional[HoldoutSummary] = None`.
+  - Propagado en `add_evaluation()` y `complete()` (patrón immutable).
+  - Nuevo `with_holdout_summary(summary)` (immutable).
+  - `to_dict()` incluye `holdout_summary.to_dict()` — solo agregados (F-ACC-006).
+- `__init__.py`: exports nuevos.
+
+### 3.3 Anti-leak — garantías (F-ACC-006)
+
+1. `BenchmarkSplit.to_dict()`/`__repr__`: solo contadores.
+2. `HoldoutSummary.to_dict()`: solo métricas agregadas.
+3. `AccuracyTestSession.to_dict()`: holdout solo como summary agregado.
+4. `HoldoutEvaluationService`: no persiste ni retorna resultados por ítem del
+   holdout; no loguea.
+5. Sin UI/API consumiendo el módulo aún → la redacción a nivel de serialización
+   del dominio ES la protección de UI (contrato para capas superiores).
+
+## 4. Tests
+
+- **Unit** `tests/test_accuracy_holdout.py`:
+  - SplitPolicy: validación ratio/mins; defaults.
+  - split_benchmarks: determinismo (misma entrada+policy → ids idénticos y mismo
+    orden), estabilidad implícita entre procesos (sha256), disjuntos + unión
+    completa, ratio exacto, mínimos respetados, salt cambia split, N<2 → holdout
+    vacío, infeasible → ValueError, duplicados → ValueError.
+  - Redacción: to_dict/repr sin preguntas, ground truth, ids de holdout.
+  - HoldoutSummary: propiedades, to_dict keys exactas.
+  - HoldoutEvaluationService: aggregación correcta (pass_rate, avg,
+    hallucinations), no expone respuestas, holdout vacío → count 0, usa las
+    preguntas del holdout contra el provider.
+  - Session: with_holdout_summary, propagación en add_evaluation/complete,
+    to_dict contiene solo agregados del holdout.
+- **Integration** `tests/integration/test_accuracy_holdout_integration.py`:
+  - Flujo E2E con `create_german_ai_liability_benchmarks()` reales → split →
+    eval set evaluado → holdout vía servicio → sesión completa → `to_dict()` →
+    JSON dump: (a) serializable, (b) sin ground truth de ningún benchmark,
+    (c) sin pregunta/respuesta de ningún benchmark del holdout.
+- **Cobertura:** ≥80% sobre `splitting.py` + `holdout_service.py` + líneas
+  nuevas de `entities.py`.
+
+## 5. Criterios de aceptación
+
+1. Split eval/holdout determinista y reproducible con política configurable.
+2. Contenido del holdout (preguntas, ground truth, respuestas, resultados por
+   ítem) ausente de: `to_dict()`/`to_dict_full()` de split y sesión, `__repr__`,
+   y output del servicio.
+3. Tests unit + integration ≥80% cobertura del código nuevo, suite existente
+   (56 tests) sigue verde.
+4. Commits convencionales, rama pusheada, sin marcar card done.
+
+## 6. Riesgos
+
+- **R1:** hash() nativo no determinista entre procesos → mitigado: SHA-256.
+- **R2:** conocer `salt` permite reconstruir qué items son holdout (no su
+  contenido/feedback) → aceptado; documentado; el split por ítem sin feedback
+  no permite tunelear por caso.
+- **R3:** merges futuros con main → la base aún no está mergeada; la rama se
+  rebaseará/mezclará junto con la base.

--- a/src/domain/accuracy_testing/__init__.py
+++ b/src/domain/accuracy_testing/__init__.py
@@ -10,34 +10,21 @@ Provides:
 - Benchmark sessions for batch evaluation
 """
 
+from .entities import AccuracyBenchmark, AccuracyEvaluation, AccuracyTestSession
+from .holdout_service import HoldoutEvaluationService
+from .interfaces import IAccuracyEvaluator, IBenchmarkRepository, IResponseProvider
+from .splitting import BenchmarkSplit, HoldoutSummary, SplitPolicy, split_benchmarks
 from .value_objects import (
-    EvaluationCriterion,
+    MAX_EVAL_INPUT_LENGTH,
     AccuracyLevel,
+    CriterionScore,
+    EvaluationCriterion,
     EvaluationStatus,
     LegalDomain,
     ResponseVerdict,
-    CriterionScore,
     validate_jurisdiction,
     validate_threshold,
-    MAX_EVAL_INPUT_LENGTH,
 )
-from .splitting import (
-    SplitPolicy,
-    BenchmarkSplit,
-    HoldoutSummary,
-    split_benchmarks,
-)
-from .entities import (
-    AccuracyEvaluation,
-    AccuracyBenchmark,
-    AccuracyTestSession,
-)
-from .interfaces import (
-    IAccuracyEvaluator,
-    IResponseProvider,
-    IBenchmarkRepository,
-)
-from .holdout_service import HoldoutEvaluationService
 
 __all__ = [
     # Value Objects

--- a/src/domain/accuracy_testing/__init__.py
+++ b/src/domain/accuracy_testing/__init__.py
@@ -10,19 +10,34 @@ Provides:
 - Benchmark sessions for batch evaluation
 """
 
-from .entities import AccuracyBenchmark, AccuracyEvaluation, AccuracyTestSession
-from .interfaces import IAccuracyEvaluator, IBenchmarkRepository, IResponseProvider
 from .value_objects import (
-    MAX_EVAL_INPUT_LENGTH,
-    AccuracyLevel,
-    CriterionScore,
     EvaluationCriterion,
+    AccuracyLevel,
     EvaluationStatus,
     LegalDomain,
     ResponseVerdict,
+    CriterionScore,
     validate_jurisdiction,
     validate_threshold,
+    MAX_EVAL_INPUT_LENGTH,
 )
+from .splitting import (
+    SplitPolicy,
+    BenchmarkSplit,
+    HoldoutSummary,
+    split_benchmarks,
+)
+from .entities import (
+    AccuracyEvaluation,
+    AccuracyBenchmark,
+    AccuracyTestSession,
+)
+from .interfaces import (
+    IAccuracyEvaluator,
+    IResponseProvider,
+    IBenchmarkRepository,
+)
+from .holdout_service import HoldoutEvaluationService
 
 __all__ = [
     # Value Objects
@@ -35,6 +50,11 @@ __all__ = [
     "validate_jurisdiction",
     "validate_threshold",
     "MAX_EVAL_INPUT_LENGTH",
+    # Splitting (F-ACC-006)
+    "SplitPolicy",
+    "BenchmarkSplit",
+    "HoldoutSummary",
+    "split_benchmarks",
     # Entities
     "AccuracyEvaluation",
     "AccuracyBenchmark",
@@ -43,4 +63,6 @@ __all__ = [
     "IAccuracyEvaluator",
     "IResponseProvider",
     "IBenchmarkRepository",
+    # Services
+    "HoldoutEvaluationService",
 ]

--- a/src/domain/accuracy_testing/entities.py
+++ b/src/domain/accuracy_testing/entities.py
@@ -19,6 +19,7 @@ from .value_objects import (
     validate_jurisdiction,
     validate_threshold,
 )
+from .splitting import HoldoutSummary
 
 
 @dataclass
@@ -235,6 +236,10 @@ class AccuracyTestSession:
     benchmarks: List[AccuracyBenchmark] = field(default_factory=list)
     evaluations: List[AccuracyEvaluation] = field(default_factory=list)
 
+    # F-ACC-006: holdout result as aggregate-only summary. Per-item holdout
+    # results must never be attached here — only HoldoutSummary aggregates.
+    holdout_summary: Optional[HoldoutSummary] = None
+
     # Stats
     total_benchmarks: int = 0
     evaluations_completed: int = 0
@@ -291,6 +296,7 @@ class AccuracyTestSession:
             ai_model=self.ai_model,
             benchmarks=self.benchmarks,
             evaluations=new_evals,
+            holdout_summary=self.holdout_summary,
             total_benchmarks=self.total_benchmarks,
             evaluations_completed=len(completed),
             evaluations_passed=passed,
@@ -322,6 +328,7 @@ class AccuracyTestSession:
             ai_model=self.ai_model,
             benchmarks=self.benchmarks,
             evaluations=self.evaluations,
+            holdout_summary=self.holdout_summary,
             total_benchmarks=self.total_benchmarks,
             evaluations_completed=self.evaluations_completed,
             evaluations_passed=self.evaluations_passed,
@@ -330,6 +337,28 @@ class AccuracyTestSession:
             total_time_ms=total_time,
             status=final_status,
             error_message=error or self.error_message,
+        )
+
+    def with_holdout_summary(self, summary: HoldoutSummary) -> "AccuracyTestSession":
+        """F-ACC-006: attach aggregate holdout summary (immutable pattern)."""
+        return AccuracyTestSession(
+            id=self.id,
+            tenant_id=self.tenant_id,
+            name=self.name,
+            description=self.description,
+            legal_domain=self.legal_domain,
+            ai_model=self.ai_model,
+            benchmarks=self.benchmarks,
+            evaluations=self.evaluations,
+            holdout_summary=summary,
+            total_benchmarks=self.total_benchmarks,
+            evaluations_completed=self.evaluations_completed,
+            evaluations_passed=self.evaluations_passed,
+            started_at=self.started_at,
+            completed_at=self.completed_at,
+            total_time_ms=self.total_time_ms,
+            status=self.status,
+            error_message=self.error_message,
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -352,6 +381,9 @@ class AccuracyTestSession:
             "completed_at": self.completed_at.isoformat() if self.completed_at else None,
             "total_time_ms": self.total_time_ms,
             "evaluations": [e.to_dict() for e in self.evaluations],
+            # F-ACC-006: holdout exposed as aggregate summary only —
+            # never per-item holdout questions, responses, or scores.
+            "holdout_summary": self.holdout_summary.to_dict() if self.holdout_summary else None,
             # F-ACC-004: tenant_id excluded from public output
         }
 

--- a/src/domain/accuracy_testing/entities.py
+++ b/src/domain/accuracy_testing/entities.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
+from .splitting import HoldoutSummary
 from .value_objects import (
     AccuracyLevel,
     CriterionScore,
@@ -19,7 +20,6 @@ from .value_objects import (
     validate_jurisdiction,
     validate_threshold,
 )
-from .splitting import HoldoutSummary
 
 
 @dataclass

--- a/src/domain/accuracy_testing/holdout_service.py
+++ b/src/domain/accuracy_testing/holdout_service.py
@@ -1,0 +1,80 @@
+"""
+Holdout Evaluation Service (F-ACC-006)
+
+Runs an accuracy evaluation over the HOLDOUT subset of a benchmark split
+and returns aggregate metrics only.
+
+Anti-gaming design: per-item results (questions, AI responses, scores,
+verdicts) are consumed to compute aggregates and then DISCARDED — they are
+never stored, returned, logged, or serialized. Only a HoldoutSummary
+(counts and rates) leaves this service, so neither UI payloads nor
+execution logs can reveal holdout content that could be tuned against.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List
+
+from .interfaces import IAccuracyEvaluator, IResponseProvider
+from .splitting import BenchmarkSplit, HoldoutSummary
+
+
+class HoldoutEvaluationService:
+    """
+    Domain service: evaluate holdout benchmarks, keep aggregates only.
+
+    Depends exclusively on domain abstractions (IAccuracyEvaluator,
+    IResponseProvider protocols), following the module's clean architecture.
+    """
+
+    def __init__(self, evaluator: IAccuracyEvaluator):
+        self._evaluator = evaluator
+
+    def run_holdout(
+        self,
+        split: BenchmarkSplit,
+        response_provider: IResponseProvider,
+        ai_model: str = "",
+    ) -> HoldoutSummary:
+        """
+        Evaluate every holdout benchmark and aggregate the results.
+
+        Args:
+            split: benchmark split; only holdout_benchmarks are evaluated.
+            response_provider: supplies AI responses for holdout questions.
+            ai_model: model identifier recorded in evaluations.
+
+        Returns:
+            HoldoutSummary with aggregate metrics. Per-item evaluations are
+            intentionally discarded after aggregation (F-ACC-006).
+        """
+        holdout: List = split.holdout_benchmarks
+        if not holdout:
+            return HoldoutSummary.empty()
+
+        count = 0
+        passed = 0
+        score_sum = 0.0
+        hallucinations = 0
+
+        for benchmark in holdout:
+            response = response_provider.get_response(benchmark.question, ai_model)
+            evaluation = self._evaluator.evaluate(benchmark, response, ai_model)
+
+            count += 1
+            if evaluation.passed:
+                passed += 1
+            score_sum += evaluation.overall_score
+            if evaluation.has_hallucinations:
+                hallucinations += 1
+            # F-ACC-006: `evaluation` (with question, response, per-item
+            # scores) is NOT retained beyond this loop iteration.
+
+        return HoldoutSummary(
+            holdout_count=count,
+            pass_rate=passed / count,
+            average_score=score_sum / count,
+            hallucination_count=hallucinations,
+            evaluated_at=datetime.now(timezone.utc),
+        )

--- a/src/domain/accuracy_testing/splitting.py
+++ b/src/domain/accuracy_testing/splitting.py
@@ -1,0 +1,259 @@
+"""
+Benchmark Splitting for AI Accuracy Testing (F-ACC-006)
+
+Deterministic eval-set / holdout-set split with anti-overfitting guarantees.
+
+Motivation (card ca3090d5): observable benchmarks can be gamed — an agent or
+team can iterate against the eval set until memorizing it (Dan Luu: agent
+overfit the benchmark up to the holdout; HF study: 6/11 ASR models memorize
+public test sets). This module keeps holdout CONTENT (questions, ground truth,
+per-item results) out of every serialized output: only aggregate counts and
+metrics ever leave the domain.
+
+Guarantees:
+1. Determinism: the split is a pure function of (benchmark ids, policy).
+   SHA-256 is used instead of Python's builtin hash(), which is salted per
+   process and would not be reproducible across runs.
+2. Redaction: BenchmarkSplit.to_dict()/__repr__ expose counts only.
+3. Aggregation: HoldoutSummary carries aggregate metrics only — no ids,
+   questions, responses, or per-item scores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, List, Optional
+
+from .value_objects import AccuracyLevel, validate_threshold
+
+if TYPE_CHECKING:  # pragma: no cover - import for type hints only
+    from .entities import AccuracyBenchmark
+
+
+# ========================================================================
+# Split Policy
+# ========================================================================
+
+
+@dataclass(frozen=True)
+class SplitPolicy:
+    """
+    Configuration for the eval/holdout split.
+
+    Attributes:
+        holdout_ratio: target fraction of benchmarks assigned to the holdout
+            set, in the open interval (0.0, 1.0).
+        salt: namespace making splits distinct per tenant/deployment. Knowing
+            the salt reveals WHICH items are holdout, never their content or
+            per-item feedback.
+        min_eval_size: minimum number of eval benchmarks (>= 1).
+        min_holdout_size: minimum number of holdout benchmarks (>= 1).
+    """
+
+    holdout_ratio: float = 0.2
+    salt: str = ""
+    min_eval_size: int = 1
+    min_holdout_size: int = 1
+
+    def __post_init__(self):
+        if not 0.0 < self.holdout_ratio < 1.0:
+            raise ValueError(f"holdout_ratio must be in (0.0, 1.0), got {self.holdout_ratio}")
+        if self.min_eval_size < 1:
+            raise ValueError(f"min_eval_size must be >= 1, got {self.min_eval_size}")
+        if self.min_holdout_size < 1:
+            raise ValueError(f"min_holdout_size must be >= 1, got {self.min_holdout_size}")
+
+
+# ========================================================================
+# Split
+# ========================================================================
+
+
+@dataclass
+class BenchmarkSplit:
+    """
+    Result of splitting a benchmark set into eval and holdout subsets.
+
+    F-ACC-006 redaction: serialization and __repr__ expose COUNTS ONLY.
+    Holdout questions, ground truth, ids, and per-item results must never
+    appear in UI payloads or execution logs.
+    """
+
+    eval_benchmarks: List["AccuracyBenchmark"] = field(default_factory=list)
+    holdout_benchmarks: List["AccuracyBenchmark"] = field(default_factory=list)
+    policy: SplitPolicy = field(default_factory=SplitPolicy)
+
+    def __post_init__(self):
+        eval_ids = [b.id for b in self.eval_benchmarks]
+        holdout_ids = [b.id for b in self.holdout_benchmarks]
+
+        if len(set(eval_ids)) != len(eval_ids):
+            raise ValueError("Duplicate benchmark ids in eval set")
+        if len(set(holdout_ids)) != len(holdout_ids):
+            raise ValueError("Duplicate benchmark ids in holdout set")
+        if set(eval_ids) & set(holdout_ids):
+            raise ValueError("Eval and holdout sets must be disjoint")
+
+        # Size constraints apply only to non-degenerate splits. An empty
+        # holdout is allowed (e.g. fewer than 2 benchmarks: nothing to hide).
+        if holdout_ids:
+            if len(holdout_ids) < self.policy.min_holdout_size:
+                raise ValueError(
+                    f"Holdout size {len(holdout_ids)} below policy minimum "
+                    f"{self.policy.min_holdout_size}"
+                )
+            if len(eval_ids) < self.policy.min_eval_size:
+                raise ValueError(
+                    f"Eval size {len(eval_ids)} below policy minimum {self.policy.min_eval_size}"
+                )
+
+    @property
+    def eval_count(self) -> int:
+        return len(self.eval_benchmarks)
+
+    @property
+    def holdout_count(self) -> int:
+        return len(self.holdout_benchmarks)
+
+    def to_dict(self) -> dict:
+        """Serialize redacted view: counts only, never content (F-ACC-006).
+
+        The salt is intentionally excluded — exposing it would help
+        reconstruct which items belong to the holdout set.
+        """
+        return {
+            "eval_count": self.eval_count,
+            "holdout_count": self.holdout_count,
+            "holdout_ratio": self.policy.holdout_ratio,
+        }
+
+    def __repr__(self) -> str:
+        """Redacted repr: counts only, safe for accidental logging."""
+        return f"BenchmarkSplit(eval_count={self.eval_count}, holdout_count={self.holdout_count})"
+
+
+def _sort_key(benchmark: "AccuracyBenchmark", salt: str):
+    """Deterministic sort key: SHA-256 of salted id (process-stable)."""
+    digest = hashlib.sha256(f"{salt}:{benchmark.id}".encode()).hexdigest()
+    return (digest, benchmark.id)
+
+
+def split_benchmarks(
+    benchmarks: List["AccuracyBenchmark"],
+    policy: Optional[SplitPolicy] = None,
+) -> BenchmarkSplit:
+    """
+    Split benchmarks into eval and holdout sets deterministically.
+
+    The split is a pure function of (benchmark ids, policy): same input,
+    same output — across runs and processes (SHA-256 bucketing, not the
+    per-process-salted builtin hash()).
+
+    Rules:
+    - Fewer than 2 benchmarks: everything goes to eval, holdout stays empty.
+    - Otherwise: holdout size k = clamp(round(N * ratio), min_holdout_size,
+      N - min_eval_size). Infeasible constraints raise ValueError.
+
+    Args:
+        benchmarks: benchmark set to split (ids must be unique).
+        policy: split configuration; defaults to SplitPolicy().
+
+    Returns:
+        BenchmarkSplit with holdout = first k benchmarks in hash order.
+    """
+    p = policy or SplitPolicy()
+
+    ids = [b.id for b in benchmarks]
+    if len(set(ids)) != len(ids):
+        raise ValueError("Duplicate benchmark ids in input set")
+
+    if len(benchmarks) < 2:
+        return BenchmarkSplit(
+            eval_benchmarks=list(benchmarks),
+            holdout_benchmarks=[],
+            policy=p,
+        )
+
+    n = len(benchmarks)
+    lower = p.min_holdout_size
+    upper = n - p.min_eval_size
+    if lower > upper:
+        raise ValueError(
+            f"Cannot split {n} benchmarks with min_eval_size={p.min_eval_size} "
+            f"and min_holdout_size={p.min_holdout_size}"
+        )
+
+    target = round(n * p.holdout_ratio)
+    k = max(lower, min(upper, target))
+
+    ordered = sorted(benchmarks, key=lambda b: _sort_key(b, p.salt))
+    holdout = ordered[:k]
+    eval_set = ordered[k:]
+
+    return BenchmarkSplit(
+        eval_benchmarks=eval_set,
+        holdout_benchmarks=holdout,
+        policy=p,
+    )
+
+
+# ========================================================================
+# Holdout Summary (aggregate-only)
+# ========================================================================
+
+
+@dataclass(frozen=True)
+class HoldoutSummary:
+    """
+    Aggregate results of a holdout evaluation run (F-ACC-006).
+
+    By design this object CANNOT leak holdout content: it holds only
+    counts and rates. No benchmark ids, questions, responses, or
+    per-item scores are kept — those are discarded after aggregation.
+    """
+
+    holdout_count: int = 0
+    pass_rate: float = 0.0
+    average_score: float = 0.0
+    hallucination_count: int = 0
+    evaluated_at: Optional[datetime] = None
+
+    def __post_init__(self):
+        validate_threshold(self.pass_rate)
+        validate_threshold(self.average_score)
+        if self.holdout_count < 0:
+            raise ValueError("holdout_count must be >= 0")
+        if self.hallucination_count < 0:
+            raise ValueError("hallucination_count must be >= 0")
+
+    @property
+    def accuracy_level(self) -> AccuracyLevel:
+        return AccuracyLevel.from_score(self.average_score)
+
+    @property
+    def is_empty(self) -> bool:
+        return self.holdout_count == 0
+
+    @classmethod
+    def empty(cls) -> "HoldoutSummary":
+        """Summary for an empty holdout run."""
+        return cls(
+            holdout_count=0,
+            pass_rate=0.0,
+            average_score=0.0,
+            hallucination_count=0,
+            evaluated_at=datetime.now(timezone.utc),
+        )
+
+    def to_dict(self) -> dict:
+        """Serialize aggregates only — safe for UI and logs (F-ACC-006)."""
+        return {
+            "holdout_count": self.holdout_count,
+            "pass_rate": self.pass_rate,
+            "average_score": self.average_score,
+            "hallucination_count": self.hallucination_count,
+            "accuracy_level": self.accuracy_level.value,
+            "evaluated_at": self.evaluated_at.isoformat() if self.evaluated_at else None,
+        }

--- a/tests/integration/test_accuracy_holdout_integration.py
+++ b/tests/integration/test_accuracy_holdout_integration.py
@@ -1,0 +1,180 @@
+"""
+Integration tests: Holdout benchmark flow (F-ACC-006)
+
+Full pipeline with the real German AI liability benchmarks and the real
+rule-based evaluator:
+
+  benchmarks -> split (eval/holdout) -> eval-set session evaluations
+            -> holdout via HoldoutEvaluationService (aggregates only)
+            -> session with holdout_summary -> public to_dict()
+
+Verifies the anti-gaming contract end to end: the serialized session is
+JSON-safe and contains NO ground truth for any benchmark and NO content
+(question/response) for any holdout benchmark.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src.domain.accuracy_testing.entities import AccuracyTestSession
+from src.domain.accuracy_testing.splitting import (
+    SplitPolicy,
+    split_benchmarks,
+)
+from src.domain.accuracy_testing.holdout_service import HoldoutEvaluationService
+from src.infrastructure.accuracy_testing.rule_based_evaluator import (
+    RuleBasedAccuracyEvaluator,
+)
+from src.infrastructure.accuracy_testing.german_ai_liability_benchmarks import (
+    create_german_ai_liability_benchmarks,
+)
+
+
+class ScriptedProvider:
+    """Replays one canned response per benchmark, keyed by question."""
+
+    def __init__(self, answers: dict[str, str], default: str = ""):
+        self.answers = answers
+        self.default = default
+        self.prompts_seen: list[str] = []
+
+    def get_response(self, prompt: str, model: str = "") -> str:
+        self.prompts_seen.append(prompt)
+        return self.answers.get(prompt, self.default)
+
+
+def _build_answers(benchmarks, quality: str) -> dict[str, str]:
+    """Build a response per benchmark: good answers echo key points."""
+    answers = {}
+    for b in benchmarks:
+        if quality == "good":
+            answers[b.question] = (
+                f"{b.ground_truth} According to the court ruling, {b.name}: "
+                + " ".join(b.key_points)
+                + " However, this may depend on the specific case."
+            )
+        else:
+            answers[b.question] = "I have no idea."
+    return answers
+
+
+@pytest.mark.integration
+class TestHoldoutFullFlow:
+    def test_end_to_end_split_eval_and_holdout(self):
+        benchmarks = create_german_ai_liability_benchmarks()
+        assert len(benchmarks) >= 4  # module ships enough cases to split
+
+        # 1. Deterministic split
+        policy = SplitPolicy(holdout_ratio=0.3, salt="integration")
+        split = split_benchmarks(benchmarks, policy)
+        assert split.holdout_count + split.eval_count == len(benchmarks)
+        assert split.holdout_count >= 1
+
+        # 2. Re-splitting is stable
+        split_again = split_benchmarks(benchmarks, policy)
+        assert {b.id for b in split_again.holdout_benchmarks} == {
+            b.id for b in split.holdout_benchmarks
+        }
+
+        # 3. Eval-set session with the real rule-based evaluator
+        evaluator = RuleBasedAccuracyEvaluator()
+        provider = ScriptedProvider(_build_answers(benchmarks, "good"))
+        session = AccuracyTestSession(
+            name="beta-verification",
+            ai_model="test-model",
+            total_benchmarks=split.eval_count,
+        )
+        for bench in split.eval_benchmarks:
+            response = provider.get_response(bench.question)
+            evaluation = evaluator.evaluate(bench, response, ai_model="test-model")
+            session = session.add_evaluation(evaluation)
+        session = session.complete()
+        assert session.evaluations_completed == split.eval_count
+
+        # 4. Holdout run: aggregates only
+        service = HoldoutEvaluationService(evaluator=evaluator)
+        summary = service.run_holdout(split, provider, ai_model="test-model")
+        assert summary.holdout_count == split.holdout_count
+        assert 0.0 <= summary.pass_rate <= 1.0
+
+        session = session.with_holdout_summary(summary)
+
+        # 5. Anti-leak contract on the public payload
+        payload = json.dumps(session.to_dict())
+        for b in benchmarks:
+            assert b.ground_truth not in payload  # F-ACC-004 (all benchmarks)
+        # F-ACC-006: holdout questions/answers never appear. Eval-set prompts
+        # are visible BY DESIGN (dev iteration set) — only holdout is sealed.
+        for b in split.holdout_benchmarks:
+            assert b.question not in payload
+        for answer in _build_answers(split.holdout_benchmarks, "good").values():
+            assert answer not in payload
+
+        # 6. Summary shape: aggregate keys only
+        holdout_dict = session.to_dict()["holdout_summary"]
+        assert set(holdout_dict.keys()) == {
+            "holdout_count",
+            "pass_rate",
+            "average_score",
+            "hallucination_count",
+            "accuracy_level",
+            "evaluated_at",
+        }
+
+    def test_holdout_summary_differs_from_eval_on_degenerate_answers(self):
+        """A model that only memorized the eval set fails the holdout.
+
+        This is the core anti-overfitting scenario: perfect answers for the
+        eval set, nonsense for the holdout — the aggregate summary must
+        reflect the drop.
+        """
+        benchmarks = create_german_ai_liability_benchmarks()
+        policy = SplitPolicy(holdout_ratio=0.3, salt="integration")
+        split = split_benchmarks(benchmarks, policy)
+
+        evaluator = RuleBasedAccuracyEvaluator()
+
+        good_eval_answers = _build_answers(split.eval_benchmarks, "good")
+        overfit_provider = ScriptedProvider(
+            {**good_eval_answers},  # memorized eval answers only
+            default="I have no idea.",  # holdout: nonsense
+        )
+
+        service = HoldoutEvaluationService(evaluator=evaluator)
+        summary = service.run_holdout(split, overfit_provider)
+
+        assert summary.holdout_count == split.holdout_count
+        # Nonsense answers on the holdout must yield a poor aggregate score
+        assert summary.average_score < 0.5
+
+        # Eval-set session with the same provider scores much higher:
+        session = AccuracyTestSession(name="overfit-demo", total_benchmarks=split.eval_count)
+        for bench in split.eval_benchmarks:
+            response = overfit_provider.get_response(bench.question)
+            session = session.add_evaluation(
+                evaluator.evaluate(bench, response, ai_model="memorizer")
+            )
+        assert session.average_score > summary.average_score
+
+    def test_split_payload_is_ui_safe(self):
+        """BenchmarkSplit serialization: counts only, no content."""
+        benchmarks = create_german_ai_liability_benchmarks()
+        split = split_benchmarks(benchmarks, SplitPolicy(holdout_ratio=0.3))
+
+        dumped = json.dumps(split.to_dict())
+        assert "eval_count" in dumped
+        for b in benchmarks:
+            assert b.question not in dumped
+            assert b.ground_truth not in dumped
+            assert b.id not in dumped
+
+        # __repr__ safe for logs too
+        r = repr(split)
+        for b in benchmarks:
+            assert b.question not in r
+            assert b.id not in r

--- a/tests/integration/test_accuracy_holdout_integration.py
+++ b/tests/integration/test_accuracy_holdout_integration.py
@@ -22,17 +22,12 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from src.domain.accuracy_testing.entities import AccuracyTestSession
-from src.domain.accuracy_testing.splitting import (
-    SplitPolicy,
-    split_benchmarks,
-)
 from src.domain.accuracy_testing.holdout_service import HoldoutEvaluationService
-from src.infrastructure.accuracy_testing.rule_based_evaluator import (
-    RuleBasedAccuracyEvaluator,
-)
+from src.domain.accuracy_testing.splitting import SplitPolicy, split_benchmarks
 from src.infrastructure.accuracy_testing.german_ai_liability_benchmarks import (
     create_german_ai_liability_benchmarks,
 )
+from src.infrastructure.accuracy_testing.rule_based_evaluator import RuleBasedAccuracyEvaluator
 
 
 class ScriptedProvider:

--- a/tests/test_accuracy_holdout.py
+++ b/tests/test_accuracy_holdout.py
@@ -20,17 +20,17 @@ import pytest
 
 from src.domain.accuracy_testing.entities import (
     AccuracyBenchmark,
-    AccuracyTestSession,
     AccuracyEvaluation,
-)
-from src.domain.accuracy_testing.value_objects import LegalDomain
-from src.domain.accuracy_testing.splitting import (
-    SplitPolicy,
-    BenchmarkSplit,
-    HoldoutSummary,
-    split_benchmarks,
+    AccuracyTestSession,
 )
 from src.domain.accuracy_testing.holdout_service import HoldoutEvaluationService
+from src.domain.accuracy_testing.splitting import (
+    BenchmarkSplit,
+    HoldoutSummary,
+    SplitPolicy,
+    split_benchmarks,
+)
+from src.domain.accuracy_testing.value_objects import LegalDomain
 
 # ========================================================================
 # Helpers

--- a/tests/test_accuracy_holdout.py
+++ b/tests/test_accuracy_holdout.py
@@ -1,0 +1,560 @@
+"""
+Tests for Holdout Benchmark Support - Accuracy Testing (F-ACC-006)
+
+Anti-overfitting design (ref: Dan Luu's agent that overfit the benchmark to
+the holdout; HF study: 6/11 ASR models memorize public test sets):
+
+- Deterministic eval/holdout split with configurable policy
+- Holdout content (questions, ground truth, per-item results) is NEVER
+  serialized: only aggregate counts/metrics are exposed
+- HoldoutSummary carries aggregate metrics only
+- HoldoutEvaluationService discards per-item results after aggregation
+- Session exposes holdout only as an aggregate summary
+"""
+
+import json
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from src.domain.accuracy_testing.entities import (
+    AccuracyBenchmark,
+    AccuracyTestSession,
+    AccuracyEvaluation,
+)
+from src.domain.accuracy_testing.value_objects import LegalDomain
+from src.domain.accuracy_testing.splitting import (
+    SplitPolicy,
+    BenchmarkSplit,
+    HoldoutSummary,
+    split_benchmarks,
+)
+from src.domain.accuracy_testing.holdout_service import HoldoutEvaluationService
+
+# ========================================================================
+# Helpers
+# ========================================================================
+
+
+def make_benchmarks(n: int, prefix: str = "bench") -> list[AccuracyBenchmark]:
+    """Create n distinct benchmarks with unique ids and marker content."""
+    out = []
+    for i in range(n):
+        out.append(
+            AccuracyBenchmark(
+                id=f"{prefix}-{i:03d}-{uuid4().hex[:8]}",
+                name=f"Benchmark {i}",
+                question=f"SECRET-QUESTION-{prefix}-{i}?",
+                ground_truth=f"SECRET-TRUTH-{prefix}-{i}",
+                key_points=[f"secret point {i}"],
+                legal_domain=LegalDomain.AI_LIABILITY,
+                jurisdiction="DE",
+            )
+        )
+    return out
+
+
+class StubEvaluator:
+    """Deterministic stub evaluator: passed iff response echoes the truth."""
+
+    def evaluate(self, benchmark, ai_response, ai_model=""):
+        passed = benchmark.ground_truth in ai_response
+        score = 0.9 if passed else 0.1
+        from src.domain.accuracy_testing.value_objects import CriterionScore, EvaluationCriterion
+
+        ev = AccuracyEvaluation(
+            benchmark_id=benchmark.id,
+            prompt=benchmark.question,
+            ai_response=ai_response,
+            criterion_scores=[
+                CriterionScore(
+                    criterion=EvaluationCriterion.FACTUAL_ACCURACY,
+                    score=score,
+                )
+            ],
+            ai_model=ai_model,
+        )
+        return ev.compute_overall()
+
+
+class HallucinatingStubEvaluator(StubEvaluator):
+    """Marks every failed evaluation as containing hallucinations."""
+
+    def evaluate(self, benchmark, ai_response, ai_model=""):
+        ev = super().evaluate(benchmark, ai_response, ai_model)
+        if not ev.passed:
+            ev.hallucinations = ["invented legal reference"]
+        return ev
+
+
+class RecordingProvider:
+    """Records every prompt it receives; returns canned answers."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.prompts_seen: list[str] = []
+
+    def get_response(self, prompt, model=""):
+        self.prompts_seen.append(prompt)
+        return self.responses.pop(0) if self.responses else ""
+
+
+# ========================================================================
+# SplitPolicy
+# ========================================================================
+
+
+class TestSplitPolicy:
+    def test_defaults(self):
+        p = SplitPolicy()
+        assert p.holdout_ratio == 0.2
+        assert p.salt == ""
+        assert p.min_eval_size == 1
+        assert p.min_holdout_size == 1
+
+    def test_custom_values(self):
+        p = SplitPolicy(holdout_ratio=0.3, salt="tenant-42", min_eval_size=4, min_holdout_size=2)
+        assert p.holdout_ratio == 0.3
+        assert p.salt == "tenant-42"
+
+    @pytest.mark.parametrize("bad_ratio", [0.0, -0.1, 1.0, 1.5])
+    def test_ratio_must_be_open_interval(self, bad_ratio):
+        with pytest.raises(ValueError):
+            SplitPolicy(holdout_ratio=bad_ratio)
+
+    @pytest.mark.parametrize("bad_min", [0, -1])
+    def test_min_sizes_must_be_positive(self, bad_min):
+        with pytest.raises(ValueError):
+            SplitPolicy(min_eval_size=bad_min)
+        with pytest.raises(ValueError):
+            SplitPolicy(min_holdout_size=bad_min)
+
+    def test_frozen(self):
+        p = SplitPolicy()
+        with pytest.raises(AttributeError):
+            p.holdout_ratio = 0.5
+
+
+# ========================================================================
+# split_benchmarks — determinism & invariants
+# ========================================================================
+
+
+class TestSplitBenchmarks:
+    def test_split_covers_all_benchmarks_exactly_once(self):
+        benches = make_benchmarks(10)
+        policy = SplitPolicy(holdout_ratio=0.2)
+        split = split_benchmarks(benches, policy)
+
+        all_ids = [b.id for b in split.eval_benchmarks] + [b.id for b in split.holdout_benchmarks]
+        assert sorted(all_ids) == sorted(b.id for b in benches)
+        assert len(all_ids) == len(set(all_ids))  # no benchmark in both subsets
+
+    def test_exact_ratio_on_large_set(self):
+        benches = make_benchmarks(20)
+        split = split_benchmarks(benches, SplitPolicy(holdout_ratio=0.2))
+        assert len(split.holdout_benchmarks) == 4
+        assert len(split.eval_benchmarks) == 16
+
+    def test_deterministic_same_input_same_output(self):
+        benches = make_benchmarks(15)
+        policy = SplitPolicy(holdout_ratio=0.2, salt="abc")
+        s1 = split_benchmarks(benches, policy)
+        s2 = split_benchmarks(benches, policy)
+        assert [b.id for b in s1.holdout_benchmarks] == [b.id for b in s2.holdout_benchmarks]
+        assert [b.id for b in s1.eval_benchmarks] == [b.id for b in s2.eval_benchmarks]
+
+    def test_deterministic_across_instance_ordering(self):
+        """Re-creating identical benchmarks (same ids) yields the same split."""
+        benches = make_benchmarks(12)
+        same_ids = [
+            AccuracyBenchmark(
+                id=b.id, name=b.name, question=b.question, ground_truth=b.ground_truth
+            )
+            for b in benches
+        ]
+        policy = SplitPolicy(holdout_ratio=0.25)
+        s1 = split_benchmarks(benches, policy)
+        s2 = split_benchmarks(same_ids, policy)
+        assert {b.id for b in s1.holdout_benchmarks} == {b.id for b in s2.holdout_benchmarks}
+
+    def test_uses_sha256_not_native_hash(self):
+        """Split must be reproducible across processes: sha256-based bucketing.
+
+        We re-implement the expected ordering with hashlib and check the
+        holdout membership matches.
+        """
+        import hashlib
+
+        benches = make_benchmarks(10)
+        policy = SplitPolicy(holdout_ratio=0.2, salt="xyz")
+        split = split_benchmarks(benches, policy)
+
+        expected_order = sorted(
+            benches,
+            key=lambda b: (hashlib.sha256(f"xyz:{b.id}".encode()).hexdigest(), b.id),
+        )
+        expected_holdout = {b.id for b in expected_order[:2]}
+        assert {b.id for b in split.holdout_benchmarks} == expected_holdout
+
+    def test_different_salt_different_split(self):
+        benches = make_benchmarks(30)
+        s1 = split_benchmarks(benches, SplitPolicy(holdout_ratio=0.2, salt="a"))
+        s2 = split_benchmarks(benches, SplitPolicy(holdout_ratio=0.2, salt="b"))
+        assert {b.id for b in s1.holdout_benchmarks} != {b.id for b in s2.holdout_benchmarks}
+
+    def test_fewer_than_two_benchmarks_all_eval(self):
+        benches = make_benchmarks(1)
+        split = split_benchmarks(benches, SplitPolicy())
+        assert len(split.eval_benchmarks) == 1
+        assert len(split.holdout_benchmarks) == 0
+
+    def test_empty_input(self):
+        split = split_benchmarks([], SplitPolicy())
+        assert split.eval_benchmarks == []
+        assert split.holdout_benchmarks == []
+
+    def test_min_sizes_respected(self):
+        benches = make_benchmarks(4)
+        split = split_benchmarks(
+            benches,
+            SplitPolicy(holdout_ratio=0.5, min_eval_size=3, min_holdout_size=1),
+        )
+        assert len(split.eval_benchmarks) >= 3
+        assert len(split.holdout_benchmarks) >= 1
+
+    def test_infeasible_constraints_raise(self):
+        benches = make_benchmarks(3)
+        with pytest.raises(ValueError):
+            split_benchmarks(
+                benches,
+                SplitPolicy(holdout_ratio=0.5, min_eval_size=2, min_holdout_size=2),
+            )
+
+    def test_duplicate_benchmark_ids_rejected(self):
+        b = make_benchmarks(1)[0]
+        with pytest.raises(ValueError):
+            split_benchmarks([b, b], SplitPolicy())
+
+
+# ========================================================================
+# BenchmarkSplit — redaction (F-ACC-006)
+# ========================================================================
+
+
+class TestBenchmarkSplitRedaction:
+    def test_to_dict_contains_only_counts(self):
+        benches = make_benchmarks(10)
+        split = split_benchmarks(benches, SplitPolicy(holdout_ratio=0.2))
+        d = split.to_dict()
+        assert d == {
+            "eval_count": 8,
+            "holdout_count": 2,
+            "holdout_ratio": 0.2,
+        }
+
+    def test_to_dict_leaks_no_holdout_content(self):
+        benches = make_benchmarks(10)
+        split = split_benchmarks(benches, SplitPolicy(holdout_ratio=0.3))
+        dumped = json.dumps(split.to_dict())
+        for b in benches:
+            assert b.question not in dumped
+            assert b.ground_truth not in dumped
+            assert b.id not in dumped
+
+    def test_repr_is_redacted(self):
+        benches = make_benchmarks(6)
+        split = split_benchmarks(benches, SplitPolicy(holdout_ratio=0.2))
+        r = repr(split)
+        assert "eval_count=" in r
+        assert "holdout_count=" in r
+        for b in benches:
+            assert b.question not in r
+            assert b.ground_truth not in r
+            assert b.id not in r
+
+    def test_counts_properties(self):
+        benches = make_benchmarks(5)
+        split = split_benchmarks(benches, SplitPolicy(holdout_ratio=0.2))
+        assert split.eval_count == len(split.eval_benchmarks)
+        assert split.holdout_count == len(split.holdout_benchmarks)
+
+
+class TestBenchmarkSplitConstructionInvariants:
+    """Direct construction must enforce the same contract as split_benchmarks."""
+
+    def test_duplicate_eval_ids_rejected(self):
+        b = make_benchmarks(1)[0]
+        with pytest.raises(ValueError, match="Duplicate benchmark ids in eval"):
+            BenchmarkSplit(eval_benchmarks=[b, b])
+
+    def test_duplicate_holdout_ids_rejected(self):
+        b = make_benchmarks(1)[0]
+        with pytest.raises(ValueError, match="Duplicate benchmark ids in holdout"):
+            BenchmarkSplit(holdout_benchmarks=[b, b])
+
+    def test_overlapping_sets_rejected(self):
+        b = make_benchmarks(1)[0]
+        other = make_benchmarks(1)[0]
+        with pytest.raises(ValueError, match="disjoint"):
+            BenchmarkSplit(eval_benchmarks=[b], holdout_benchmarks=[b, other])
+
+    def test_holdout_below_policy_minimum_rejected(self):
+        b = make_benchmarks(1)[0]
+        other = make_benchmarks(1)[0]
+        policy = SplitPolicy(min_holdout_size=2)
+        with pytest.raises(ValueError, match="below policy minimum"):
+            BenchmarkSplit(eval_benchmarks=[b], holdout_benchmarks=[other], policy=policy)
+
+    def test_eval_below_policy_minimum_rejected(self):
+        benches = make_benchmarks(2)
+        policy = SplitPolicy(min_eval_size=2)
+        with pytest.raises(ValueError, match="below policy minimum"):
+            BenchmarkSplit(
+                eval_benchmarks=[benches[0]], holdout_benchmarks=[benches[1]], policy=policy
+            )
+
+    def test_empty_holdout_allowed_regardless_of_minimum(self):
+        b = make_benchmarks(1)[0]
+        split = BenchmarkSplit(eval_benchmarks=[b], policy=SplitPolicy(min_holdout_size=2))
+        assert split.holdout_count == 0
+
+
+# ========================================================================
+# HoldoutSummary
+# ========================================================================
+
+
+class TestHoldoutSummary:
+    def test_properties_and_level(self):
+        s = HoldoutSummary(
+            holdout_count=10,
+            pass_rate=0.8,
+            average_score=0.85,
+            hallucination_count=1,
+            evaluated_at=datetime.now(timezone.utc),
+        )
+        assert s.accuracy_level.value == "good"
+        assert s.holdout_count == 10
+
+    def test_to_dict_aggregates_only(self):
+        s = HoldoutSummary(
+            holdout_count=5,
+            pass_rate=0.6,
+            average_score=0.7,
+            hallucination_count=0,
+            evaluated_at=datetime(2026, 8, 23, 12, 0, tzinfo=timezone.utc),
+        )
+        d = s.to_dict()
+        assert set(d.keys()) == {
+            "holdout_count",
+            "pass_rate",
+            "average_score",
+            "hallucination_count",
+            "accuracy_level",
+            "evaluated_at",
+        }
+
+    def test_empty_summary(self):
+        s = HoldoutSummary.empty()
+        assert s.holdout_count == 0
+        assert s.pass_rate == 0.0
+        assert s.is_empty
+
+    @pytest.mark.parametrize(
+        "bad", [(-0.1, 0.5, 0, 0), (0.5, -0.1, 0, 0), (0.5, 0.5, -1, 0), (0.5, 0.5, 0, -1)]
+    )
+    def test_invalid_values_rejected(self, bad):
+        with pytest.raises(ValueError):
+            HoldoutSummary(
+                holdout_count=bad[2],
+                pass_rate=bad[0],
+                average_score=bad[1],
+                hallucination_count=bad[3],
+                evaluated_at=datetime.now(timezone.utc),
+            )
+
+    def test_frozen(self):
+        s = HoldoutSummary.empty()
+        with pytest.raises(AttributeError):
+            s.pass_rate = 0.9
+
+
+# ========================================================================
+# HoldoutEvaluationService
+# ========================================================================
+
+
+class TestHoldoutEvaluationService:
+    def _make_split(self, n=10):
+        benches = make_benchmarks(n, prefix="hold")
+        return benches, split_benchmarks(benches, SplitPolicy(holdout_ratio=0.2))
+
+    def test_returns_aggregate_summary(self):
+        _, split = self._make_split()
+        provider = RecordingProvider(responses=[])
+        service = HoldoutEvaluationService(evaluator=StubEvaluator())
+        summary = service.run_holdout(split, provider)
+        assert isinstance(summary, HoldoutSummary)
+        assert summary.holdout_count == len(split.holdout_benchmarks)
+        assert 0.0 <= summary.average_score <= 1.0
+
+    def test_summary_math_is_correct(self):
+        _, split = self._make_split(10)
+        holdout_benches = split.holdout_benchmarks
+        # Provider answers half correctly (echo ground truth), half wrongly
+        responses = [
+            b.ground_truth if i % 2 == 0 else "totally wrong answer"
+            for i, b in enumerate(holdout_benches)
+        ]
+        provider = RecordingProvider(responses=responses)
+        service = HoldoutEvaluationService(evaluator=StubEvaluator())
+        summary = service.run_holdout(split, provider)
+
+        expected_pass = sum(1 for i in range(len(holdout_benches)) if i % 2 == 0)
+        assert summary.holdout_count == len(holdout_benches)
+        assert summary.pass_rate == pytest.approx(expected_pass / len(holdout_benches))
+        expected_avg = (0.9 * expected_pass + 0.1 * (len(holdout_benches) - expected_pass)) / len(
+            holdout_benches
+        )
+        assert summary.average_score == pytest.approx(expected_avg)
+
+    def test_evaluates_only_holdout_questions(self):
+        _, split = self._make_split(10)
+        provider = RecordingProvider(responses=["x"] * len(split.holdout_benchmarks))
+        service = HoldoutEvaluationService(evaluator=StubEvaluator())
+        service.run_holdout(split, provider)
+
+        holdout_questions = {b.question for b in split.holdout_benchmarks}
+        eval_questions = {b.question for b in split.eval_benchmarks}
+        assert set(provider.prompts_seen) == holdout_questions
+        assert not (set(provider.prompts_seen) & eval_questions)
+
+    def test_summary_and_dict_leak_no_content(self):
+        benches, split = self._make_split(10)
+        provider = RecordingProvider(responses=["SECRET-AI-ANSWER"] * len(split.holdout_benchmarks))
+        service = HoldoutEvaluationService(evaluator=StubEvaluator())
+        summary = service.run_holdout(split, provider)
+
+        dumped = json.dumps(summary.to_dict())
+        for b in benches:
+            assert b.question not in dumped
+            assert b.ground_truth not in dumped
+        assert "SECRET-AI-ANSWER" not in dumped
+
+    def test_empty_holdout_returns_zero_summary(self):
+        benches = make_benchmarks(1)
+        split = split_benchmarks(benches, SplitPolicy())
+        service = HoldoutEvaluationService(evaluator=StubEvaluator())
+        summary = service.run_holdout(split, RecordingProvider([]))
+        assert summary.holdout_count == 0
+        assert summary.pass_rate == 0.0
+
+    def test_hallucination_count_aggregated(self):
+        benches = make_benchmarks(10)
+        split = split_benchmarks(benches, SplitPolicy(holdout_ratio=0.4))
+        # Every answer wrong -> every holdout evaluation hallucinates
+        provider = RecordingProvider(responses=["wrong"] * len(split.holdout_benchmarks))
+        service = HoldoutEvaluationService(evaluator=HallucinatingStubEvaluator())
+        summary = service.run_holdout(split, provider)
+        assert summary.hallucination_count == len(split.holdout_benchmarks)
+        assert summary.pass_rate == 0.0
+
+    def test_service_does_not_log_content(self, capsys):
+        """The service module must not print/write holdout content anywhere."""
+        _, split = self._make_split(10)
+        provider = RecordingProvider(responses=["answer"] * len(split.holdout_benchmarks))
+        service = HoldoutEvaluationService(evaluator=StubEvaluator())
+        service.run_holdout(split, provider)
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        for b in split.holdout_benchmarks:
+            assert b.question not in combined
+            assert b.ground_truth not in combined
+
+
+# ========================================================================
+# Session integration (F-ACC-006)
+# ========================================================================
+
+
+class TestSessionHoldoutIntegration:
+    def test_with_holdout_summary_immutable(self):
+        session = AccuracyTestSession(name="s")
+        summary = HoldoutSummary(
+            holdout_count=2,
+            pass_rate=1.0,
+            average_score=0.95,
+            hallucination_count=0,
+            evaluated_at=datetime.now(timezone.utc),
+        )
+        updated = session.with_holdout_summary(summary)
+        assert updated is not session
+        assert updated.holdout_summary is summary
+        assert session.holdout_summary is None
+
+    def test_summary_propagates_through_add_evaluation(self):
+        summary = HoldoutSummary(
+            holdout_count=1,
+            pass_rate=1.0,
+            average_score=1.0,
+            hallucination_count=0,
+            evaluated_at=datetime.now(timezone.utc),
+        )
+        session = AccuracyTestSession(name="s").with_holdout_summary(summary)
+        ev = AccuracyEvaluation(benchmark_id="b1")
+        session2 = session.add_evaluation(ev)
+        assert session2.holdout_summary is summary
+
+    def test_summary_propagates_through_complete(self):
+        summary = HoldoutSummary(
+            holdout_count=1,
+            pass_rate=0.0,
+            average_score=0.2,
+            hallucination_count=0,
+            evaluated_at=datetime.now(timezone.utc),
+        )
+        session = AccuracyTestSession(name="s").with_holdout_summary(summary)
+        done = session.complete()
+        assert done.holdout_summary is summary
+
+    def test_session_to_dict_holdout_aggregates_only(self):
+        benches = make_benchmarks(10)
+        split = split_benchmarks(benches, SplitPolicy(holdout_ratio=0.2))
+        provider = RecordingProvider(responses=["ans"] * len(split.holdout_benchmarks))
+        service = HoldoutEvaluationService(evaluator=StubEvaluator())
+        summary = service.run_holdout(split, provider)
+
+        session = AccuracyTestSession(name="verification").with_holdout_summary(summary)
+        d = session.to_dict()
+
+        assert "holdout_summary" in d
+        assert set(d["holdout_summary"].keys()) == {
+            "holdout_count",
+            "pass_rate",
+            "average_score",
+            "hallucination_count",
+            "accuracy_level",
+            "evaluated_at",
+        }
+
+    def test_session_to_dict_leaks_no_holdout_content(self):
+        benches = make_benchmarks(10)
+        split = split_benchmarks(benches, SplitPolicy(holdout_ratio=0.3))
+        provider = RecordingProvider(
+            responses=["SECRET-HOLDOUT-ANSWER"] * len(split.holdout_benchmarks)
+        )
+        service = HoldoutEvaluationService(evaluator=StubEvaluator())
+        summary = service.run_holdout(split, provider)
+
+        session = AccuracyTestSession(name="verification").with_holdout_summary(summary)
+        dumped = json.dumps(session.to_dict())
+
+        for b in split.holdout_benchmarks:
+            assert b.question not in dumped
+            assert b.ground_truth not in dumped
+        assert "SECRET-HOLDOUT-ANSWER" not in dumped
+        # Full view must not leak either
+        dumped_full = json.dumps(session.to_dict_full())
+        assert "SECRET-HOLDOUT-ANSWER" not in dumped_full


### PR DESCRIPTION
## Summary

Card ca3090d5 output (pipeline APPROVED 08-23), rebased + reformatted for current main.

- Deterministic eval/holdout split (SHA-256 bucketing, `SplitPolicy`)
- `HoldoutEvaluationService`: per-item results discarded, aggregates only
- `HoldoutSummary`: aggregate-only dataclass (counts + rates)
- Redaction in `BenchmarkSplit.to_dict()`/`__repr__` (counts only)

**Stacks on #88** (german-ai-liability): merged diff shows 3 commits until #88 lands; net contribution of THIS PR after #88 = the 2 holdout commits.

## Formatting

Re-formatted with CI pins: black 24.1.1, isort 5.13.2, ruff 0.2.1 (local 8.x versions rejected).

## Tests

- `pytest tests/test_accuracy_holdout.py tests/test_accuracy_testing.py -o addopts=""` → 106 passed

Card: c9825844 (merge leg)