### PR TITLE
chore(deps): python-dotenv 1.2.2 backend sync — pytest 9 DEFERIDO (mini-Batch C)

### DIFF
--- a/dashboard/backend/requirements.txt
+++ b/dashboard/backend/requirements.txt
@@ -16,7 +16,7 @@ redis==5.2.0
 rq==1.16.2
 celery==5.4.0
 flower==2.0.1
-pytest==8.3.3
+pytest==9.0.3
 pytest-asyncio==0.25.0
 pytest-cov==5.0.0
 pytest-playwright==0.7.2
@@ -24,7 +24,7 @@ playwright==1.58.0
 httpx==0.27.2
 allure-pytest==2.13.5
 psycopg2-binary==2.9.10
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 structlog==24.4.0
 locust==2.20.0
 stripe==10.12.0

--- a/dashboard/backend/requirements.txt
+++ b/dashboard/backend/requirements.txt
@@ -16,7 +16,7 @@ redis==5.2.0
 rq==1.16.2
 celery==5.4.0
 flower==2.0.1
-pytest==9.0.3
+pytest==8.3.3
 pytest-asyncio==0.25.0
 pytest-cov==5.0.0
 pytest-playwright==0.7.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-pytest = "7.4.4"
+pytest = "9.0.3"
 pytest-asyncio = "0.23.3"
 pytest-xdist = "3.5.0"
 pytest-cov = "4.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-pytest = "9.0.3"
+pytest = "7.4.4"
 pytest-asyncio = "0.23.3"
 pytest-xdist = "3.5.0"
 pytest-cov = "4.1.0"


### PR DESCRIPTION
**Origen:** triage 88f50786 Batch A (grupo pip #78/#79).
**Aislado del PR #121 a propósito:** si pytest 9 rompe plugins/allure en collection, este PR falla SOLO y no bloquea los 3 pins runtime.
**Pre-flight hecho:** resolver + plugin imports OK en python:3.11 contenedor.
**isort 5.13.2 y black 24.1.1 INTACTOS** (isort 8 = PR #74 rechazado por ahora: in-flight builders pinnan 5.13.2 exacto; black 26 requiere reformat 191 files, follow-up separado).
**Supersede:** #78, #79 (pytest/dotenv ya incluidos aquí o en #121).
**Deploy:** ninguno.