### PR TITLE
fix(deps): bleach 6.4.0 — URI-scheme bypass en sanitizer de feedback (Batch B-2)

### DIFF
--- a/dashboard/backend/requirements.txt
+++ b/dashboard/backend/requirements.txt
@@ -29,7 +29,7 @@ structlog==24.4.0
 locust==2.20.0
 stripe==10.12.0
 email-validator==2.2.0
-bleach==6.2.0
+bleach==6.4.0
 prometheus-client==0.20.0
 pyotp==2.9.0
 qrcode[pil]==7.4.2


### PR DESCRIPTION
**Origen:** triaje 88f50786 pendiente menor B-2 — criterio: 'si backend sanitiza user content con bleach -> sube prioridad'. **Confirmado:** feedback_service.py:68 sanitiza feedback de usuario con bleach.clean(tags=[], strip=True) → alerta MED aplica a runtime real.
**Cambio:** 1 línea, requirements.txt dashboard/backend 6.2.0→6.4.0.
**Deploy:** ninguno.