### PR TITLE
chore(deps): pytest 9.0.3 + pytest-asyncio 1.4.0 family — Batch C sub-task 1

### DIFF
--- a/dashboard/backend/requirements.txt
+++ b/dashboard/backend/requirements.txt
@@ -16,10 +16,10 @@ redis==5.2.0
 rq==1.16.2
 celery==5.4.0
 flower==2.0.1
-pytest==8.3.3
-pytest-asyncio==0.25.0
-pytest-cov==5.0.0
-pytest-playwright==0.7.2
+pytest==9.0.3
+pytest-asyncio==1.4.0
+pytest-cov==7.1.0
+pytest-playwright==0.9.0
 playwright==1.58.0
 httpx==0.27.2
 allure-pytest==2.13.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,12 @@ packages = [{include = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-pytest = "7.4.4"
-pytest-asyncio = "0.23.3"
-pytest-xdist = "3.5.0"
-pytest-cov = "4.1.0"
+pytest = "9.0.3"
+pytest-asyncio = "1.4.0"
+pytest-xdist = "3.8.0"
+pytest-cov = "7.1.0"
 allure-pytest = "2.13.5"
-pytest-html = "4.1.1"
+pytest-html = "4.2.0"
 httpx = "0.26.0"
 requests = "2.34.2"
 playwright = "1.41.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 # QA-FRAMEWORK - Dependencies
 
 # Core Testing Framework
-pytest==7.4.4
-pytest-asyncio==0.23.3
-pytest-xdist==3.5.0
-pytest-cov==4.1.0
+pytest==9.0.3
+pytest-asyncio==1.4.0
+pytest-xdist==3.8.0
+pytest-cov==7.1.0
 allure-pytest==2.13.5  # Fixed: correct package name
-pytest-html==4.1.1
+pytest-html==4.2.0
 
 # HTTP Clients
 httpx==0.26.0
@@ -32,7 +32,7 @@ allure-python-commons==2.13.5
 
 # Performance Testing
 locust==2.22.0
-pytest-benchmark==4.0.0
+pytest-benchmark==5.2.3
 
 # Security Testing
 bandit==1.7.6


### PR DESCRIPTION
## Qué
Familia pytest a 9.x coherente en los 3 manifests (root pyproject + root requirements.txt sync + dashboard/backend), cierra las alerts pytest pendientes del triage 2026-08-24.

| Paquete | Antes | Después |
|---|---|---|
| pytest (root) | 7.4.4 | 9.0.3 |
| pytest-asyncio (root) | 0.23.3 | 1.4.0 |
| pytest-xdist | 3.5.0 | 3.8.0 |
| pytest-cov (root/backend) | 4.1.0/5.0.0 | 7.1.0 |
| pytest-html | 4.1.1 | 4.2.0 |
| pytest-benchmark (root reqs) | 4.0.0 | 5.2.3 — **supersede #126** |
| pytest (backend) | 8.3.3 | 9.0.3 |
| pytest-asyncio (backend) | 0.25.0 | 1.4.0 |
| pytest-playwright (backend) | 0.7.2 | 0.9.0 — **supersede #51** |

## Collection demostrada (condición obligatoria de la card 5fcf05ab)
Smokes en contenedores throwaway python:3.11-slim, control (pins actuales) vs tratamiento (familia 9):
- **Root**: 904 tests collected; los 11 errores de collection son idénticos a pre-existentes y 100% ambientales (10× `No module named 'fastapi'` + 1× `bcrypt` — root requirements.txt no incluye runtime deps; el CI root instala vía poetry). El aborte `pytest_asyncio/plugin.py:626 pytest_collectstart` que forzó el defer en #122 NO ocurre con 1.4.0.
- **Backend**: 872 tests collected; 1 error pre-existente idéntico en control y tratamiento (`tests/test_analytics_service.py`).
- Resolver limpio en ambos (allure-pytest 2.13.5 revalidado y sin cambios).

Card: 5fcf05ab (Batch C sub-tarea 1). Reporte: reports/devops/dependabot-triage-2026-08-24.md §7-8.