### PR TITLE
feat(auth): hardening L-1 + L-2 + adv-1 fail-closed + JWT edges (card 86464839)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Auth hardening (cards L-1, L-2, adv-1, JWT edges)**: four fixes on the
+  QA Visual auth path. L-1: `get_current_user` (and the optional-auth and
+  QA Visual principal paths behind it) now rejects refresh tokens — the
+  `type` claim must be absent (pre-tag tokens) or `"access"`; access
+  tokens are minted with `type=access`. L-2: `get_current_user` rejects
+  deactivated accounts with 403 immediately, closing the inconsistency
+  with the refresh and optional paths. adv-1 (fail-closed storage):
+  `QAVisualReportStore.get_report` requires an explicit `owner` or
+  `is_admin=True` — a bare call raises `ValueError`, an owner-scoped read
+  of someone else's report raises `ReportAccessDenied` (router answers
+  403), so authorization no longer lives only in the endpoint layer
+  (BOLA guard). JWT edge (a): expired tokens answer 401, never 500
+  (regression-tested). JWT edge (b): `QAVisualPrincipal(owner="")` is
+  invalid at the model (`field_validator`), the router answers 422 for
+  blank-owner principals that bypass validation, and the dashboard
+  adapter `get_qa_visual_principal` rejects users without a usable
+  username. Applied to both module copies (root `src/` and the vendored
+  `dashboard/backend/src/`).
+
 ### Added
 
 - **Accuracy testing API wiring (card c9825844)**: the accuracy_testing

--- a/dashboard/backend/services/auth_service.py
+++ b/dashboard/backend/services/auth_service.py
@@ -27,6 +27,11 @@ logger = get_logger(__name__)
 # Password hashing
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
+# L-1: only these values of the ``type`` claim may authenticate access
+# endpoints. ``None`` keeps tokens minted before the type tag valid;
+# anything else (``refresh``, unknown types) must use its own flow.
+ACCESS_TOKEN_TYPES = (None, "access")
+
 # Security scheme
 security = HTTPBearer()
 
@@ -52,7 +57,7 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -
     else:
         expire = datetime.utcnow() + timedelta(minutes=settings.access_token_expire_minutes)
 
-    to_encode.update({"exp": expire})
+    to_encode.update({"exp": expire, "type": "access"})
     encoded_jwt = jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
     return encoded_jwt
 
@@ -103,6 +108,14 @@ async def get_current_user(
         if username is None:
             logger.warning("JWT validation failed - no subject claim")
             raise credentials_exception
+        # L-1: a refresh token (or any non-access type) must never
+        # authenticate an access-token endpoint.
+        if payload.get("type") not in ACCESS_TOKEN_TYPES:
+            logger.warning(
+                "JWT validation failed - invalid token type",
+                token_type=payload.get("type"),
+            )
+            raise credentials_exception
     except JWTError as e:
         logger.warning("JWT validation failed", error=str(e))
         raise credentials_exception
@@ -113,6 +126,16 @@ async def get_current_user(
     if user is None:
         logger.warning("JWT validation failed - user not found", username=username)
         raise credentials_exception
+
+    # L-2: deactivated users lose API access immediately, mirroring the
+    # refresh and optional paths.
+    if not user.is_active:
+        logger.warning("JWT validation failed - user inactive", username=username, user_id=user.id)
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User account is inactive",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
     logger.debug("JWT token validated successfully", username=username, user_id=user.id)
     return user
@@ -219,6 +242,14 @@ async def get_qa_visual_principal(
     ``owner`` is the username reports are scoped to; ``is_superuser`` is
     the dashboard's existing admin role and bypasses the scoping.
     """
+    # JWT edge (b): an empty identity must never scope reports to an
+    # empty owner; reject it before it reaches the module.
+    if not current_user.username or not current_user.username.strip():
+        logger.warning("QA Visual principal rejected - empty username", user_id=current_user.id)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Authenticated user has no usable username to scope reports",
+        )
     return QAVisualPrincipal(
         owner=current_user.username,
         is_admin=bool(current_user.is_superuser),
@@ -246,6 +277,11 @@ async def get_current_user_optional(
         )
         username: str = payload.get("sub")
         if username is None:
+            return None
+        # L-1: refresh tokens are anonymous on optional endpoints, same
+        # rule as get_current_user.
+        if payload.get("type") not in ACCESS_TOKEN_TYPES:
+            logger.debug("Optional auth - non-access token type, returning None")
             return None
 
         result = await db.execute(select(User).where(User.username == username))

--- a/dashboard/backend/src/infrastructure/qa_visual/endpoint.py
+++ b/dashboard/backend/src/infrastructure/qa_visual/endpoint.py
@@ -32,6 +32,7 @@ from src.infrastructure.qa_visual.analyzer import (
     build_trend_report,
 )
 from src.infrastructure.qa_visual.models import AnalyzeResponse, QAVisualPrincipal
+from src.infrastructure.qa_visual.storage import ReportAccessDenied
 
 logger = logging.getLogger(__name__)
 
@@ -52,22 +53,31 @@ def _owner_scope(principal: QAVisualPrincipal | None) -> str | None:
     """Owner a non-admin principal is scoped to; None sees everything."""
     if principal is None or principal.is_admin:
         return None
+    # JWT edge (b): a blank identity must never become a report scope.
+    if not principal.owner or not principal.owner.strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Principal owner must be a non-empty string",
+        )
     return principal.owner
 
 
-def _require_report_access(report: dict, principal: QAVisualPrincipal | None) -> None:
-    """Raise 403 unless the principal owns the report or is an admin.
+def _stamp_owner(principal: QAVisualPrincipal | None) -> str | None:
+    """Owner stamped on newly created reports (analyze).
 
-    S-1R: reports persisted before owner-scoping (owner absent) belong to
-    no regular user, so only admins may read them.
+    Admins without a usable identity produce unowned reports (admin-only
+    reads) instead of reports scoped to a blank owner.
     """
-    if principal is None or principal.is_admin:
-        return
-    if report.get("owner") != principal.owner:
+    if principal is None:
+        return None
+    if not principal.owner or not principal.owner.strip():
+        if principal.is_admin:
+            return None
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Not allowed to access this report",
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Principal owner must be a non-empty string",
         )
+    return principal.owner
 
 
 async def _read_capped(upload: UploadFile) -> bytes:
@@ -171,7 +181,7 @@ def create_qa_visual_router(
             response = await get_analyzer().analyze(
                 image_bytes,
                 target=target,
-                owner=principal.owner if principal else None,
+                owner=_stamp_owner(principal),
             )
         except QAVisualAnalysisError as exc:
             # S-3 (CWE-209): full detail goes to server logs only; the HTTP
@@ -211,13 +221,24 @@ def create_qa_visual_router(
         principal: QAVisualPrincipal | None = Depends(principal_dependency),
     ) -> dict:
         """Return one stored report by id (owner or admin only)."""
-        report = get_analyzer().store.get_report(report_id)
+        try:
+            report = get_analyzer().store.get_report(
+                report_id,
+                owner=_owner_scope(principal),
+                # Standalone mounts (no principal) keep their documented
+                # legacy unscoped behaviour: an explicit privileged read.
+                is_admin=principal is None or principal.is_admin,
+            )
+        except ReportAccessDenied:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not allowed to access this report",
+            )
         if report is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Report '{report_id}' not found",
             )
-        _require_report_access(report, principal)
         return report
 
     @router.get("/trends")

--- a/dashboard/backend/src/infrastructure/qa_visual/models.py
+++ b/dashboard/backend/src/infrastructure/qa_visual/models.py
@@ -7,7 +7,7 @@ is prompted to return (validated in Fase A: 5/5 literal texts, 0 hallucinations)
 from datetime import UTC, datetime
 from enum import Enum
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class Severity(str, Enum):
@@ -111,6 +111,16 @@ class QAVisualPrincipal(BaseModel):
 
     owner: str
     is_admin: bool = False
+
+    @field_validator("owner")
+    @classmethod
+    def _owner_not_blank(cls, value: str) -> str:
+        # JWT edge (b): an empty identity must never become a report
+        # scope (empty-owner reports would be readable by empty-owner
+        # principals).
+        if not value or not value.strip():
+            raise ValueError("owner must be a non-empty string")
+        return value
 
 
 class TrendPoint(BaseModel):

--- a/dashboard/backend/src/infrastructure/qa_visual/storage.py
+++ b/dashboard/backend/src/infrastructure/qa_visual/storage.py
@@ -31,6 +31,14 @@ def _sanitize_target(target: str) -> str:
     return sanitized or "unknown"
 
 
+class ReportAccessDenied(Exception):
+    """The report exists but is not accessible to the requesting owner (adv-1).
+
+    Raised instead of returning ``None`` so routers can answer 403
+    without a second unscoped lookup leaking report existence.
+    """
+
+
 class QAVisualReportStore:
     """Saves and queries QA Visual reports as JSON files."""
 
@@ -78,12 +86,33 @@ class QAVisualReportStore:
         reports.sort(key=lambda r: r.get("timestamp") or "", reverse=True)
         return reports[:limit] if limit else reports
 
-    def get_report(self, report_id: str) -> dict[str, Any] | None:
-        """Return one report by id, or None."""
+    def get_report(
+        self,
+        report_id: str,
+        owner: str | None = None,
+        is_admin: bool = False,
+    ) -> dict[str, Any] | None:
+        """Return one report by id if the caller may read it (adv-1).
+
+        Fail-closed: callers must state who is asking — an explicit
+        ``owner`` to scope the read, or ``is_admin=True`` to lift the
+        scoping. A call with neither is a programming error, so a new
+        caller can never silently read every tenant's reports.
+
+        Returns ``None`` when no report with that id exists; raises
+        ``ReportAccessDenied`` when it exists but belongs to another
+        owner (legacy unowned reports are admin-only, as everywhere).
+        """
+        if owner is None and not is_admin:
+            raise ValueError(
+                "get_report() requires an explicit owner or is_admin=True (fail-closed)"
+            )
         for path in self._dir.glob("*.json") if self._dir.exists() else []:
             report = self._read_report(path)
             if report and report.get("report_id") == report_id:
-                return report
+                if is_admin or report.get("owner") == owner:
+                    return report
+                raise ReportAccessDenied(report_id)
         return None
 
     def get_baseline(self, target: str, owner: str | None = None) -> dict[str, Any] | None:

--- a/dashboard/backend/tests/infrastructure/test_qa_visual_storage_fail_closed.py
+++ b/dashboard/backend/tests/infrastructure/test_qa_visual_storage_fail_closed.py
@@ -1,0 +1,77 @@
+"""Fail-closed storage access tests for the dashboard's QA Visual module copy.
+
+Dashboard-side mirror of tests/unit/infrastructure (root)
+/test_qa_visual_storage_fail_closed.py: the dashboard backend ships its own
+copy of the qa_visual module, so the adv-1 fail-closed contract (explicit
+owner or is_admin, never a silent open read) and the JWT edge (b) owner
+validation must hold here too.
+"""
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from src.infrastructure.qa_visual.models import AnalyzeResponse, QAAnalysis, QAVisualPrincipal
+from src.infrastructure.qa_visual.storage import QAVisualReportStore
+
+
+def make_response(report_id: str, owner: str | None, score: int = 95) -> AnalyzeResponse:
+    return AnalyzeResponse(
+        report_id=report_id,
+        target="amc",
+        analysis=QAAnalysis(overall_score=score, summary="seeded"),
+        passed=True,
+        score=score,
+        threshold=80,
+        cost_usd=0.000428,
+        latency_s=4.37,
+        model="deepseek-v4-flash-vision-exp",
+        regression_detected=False,
+        owner=owner,
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> QAVisualReportStore:
+    store = QAVisualReportStore(reports_dir=str(tmp_path / "qa-visual"))
+    store.save(make_response("rep-alice", owner="alice"))
+    store.save(make_response("rep-bob", owner="bob"))
+    return store
+
+
+class TestGetReportFailClosed:
+    """adv-1: the store itself enforces who may read a report."""
+
+    def test_bare_call_raises_value_error(self, store):
+        with pytest.raises(ValueError, match="owner"):
+            store.get_report("rep-alice")
+
+    def test_owner_reads_own_report(self, store):
+        report = store.get_report("rep-alice", owner="alice")
+        assert report is not None
+        assert report["report_id"] == "rep-alice"
+
+    def test_owner_cannot_read_others_report(self, store):
+        from src.infrastructure.qa_visual.storage import ReportAccessDenied
+
+        with pytest.raises(ReportAccessDenied):
+            store.get_report("rep-alice", owner="bob")
+
+    def test_admin_reads_any_report(self, store):
+        report = store.get_report("rep-bob", is_admin=True)
+        assert report is not None
+
+    def test_missing_report_returns_none_for_owner(self, store):
+        assert store.get_report("missing", owner="alice") is None
+
+
+class TestPrincipalOwnerValidation:
+    """JWT edge (b): an empty owner identity is invalid at the model."""
+
+    def test_empty_owner_rejected_by_model(self):
+        with pytest.raises(ValidationError):
+            QAVisualPrincipal(owner="")
+
+    def test_valid_owner_accepted_by_model(self):
+        assert QAVisualPrincipal(owner="alice").owner == "alice"

--- a/dashboard/backend/tests/test_qa_visual_owner_scoping.py
+++ b/dashboard/backend/tests/test_qa_visual_owner_scoping.py
@@ -22,13 +22,13 @@ level in tests/unit/infrastructure/test_qa_visual_owner_scoping.py).
 """
 
 import importlib
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from database import get_db_session
 from fastapi.testclient import TestClient
 from models import User
-from services.auth_service import create_access_token
+from services.auth_service import create_access_token, create_refresh_token
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 
 from src.infrastructure.qa_visual.models import AnalyzeResponse, QAAnalysis
@@ -126,6 +126,13 @@ async def auth_headers(qa_app):
                     is_active=True,
                     is_superuser=True,
                 ),
+                User(
+                    username="dormant",
+                    email="dormant@example.com",
+                    hashed_password="x",
+                    is_active=False,
+                    is_superuser=False,
+                ),
             ]
         )
         await session.commit()
@@ -140,6 +147,16 @@ async def auth_headers(qa_app):
             "alice": {"Authorization": f"Bearer {create_access_token({'sub': 'alice'})}"},
             "bob": {"Authorization": f"Bearer {create_access_token({'sub': 'bob'})}"},
             "admin": {"Authorization": f"Bearer {create_access_token({'sub': 'root'})}"},
+            # L-2: valid credentials for a deactivated account.
+            "dormant": {"Authorization": f"Bearer {create_access_token({'sub': 'dormant'})}"},
+            # L-1: valid refresh token minted for alice.
+            "alice_refresh": {"Authorization": f"Bearer {create_refresh_token({'sub': 'alice'})}"},
+            # JWT edge (a): well-formed but expired access token.
+            "expired": {
+                "Authorization": (
+                    f"Bearer {create_access_token({'sub': 'alice'}, expires_delta=timedelta(minutes=-5))}"
+                )
+            },
         }
     finally:
         qa_app.dependency_overrides.pop(get_db_session, None)
@@ -240,3 +257,48 @@ class TestPrincipalAdapter:
         principal = await get_qa_visual_principal(current_user=user)
         assert principal.owner == "root"
         assert principal.is_admin is True
+
+
+class TestAuthHardeningMatrix:
+    """Auth regression matrix (cards L-1, L-2, JWT edges) on the real app.
+
+    Rows: valid access / refresh-as-access / expired / inactive / admin.
+    """
+
+    def test_valid_access_token_still_authenticates(self, client, auth_headers):
+        response = client.get("/api/v1/qa-visual/reports", headers=auth_headers["alice"])
+        assert response.status_code == 200
+
+    def test_refresh_token_as_access_rejected_401(self, client, auth_headers):
+        response = client.get("/api/v1/qa-visual/reports", headers=auth_headers["alice_refresh"])
+        assert response.status_code == 401
+
+    def test_refresh_token_on_single_report_rejected_401(self, client, auth_headers):
+        response = client.get(
+            "/api/v1/qa-visual/reports/rep-alice-1", headers=auth_headers["alice_refresh"]
+        )
+        assert response.status_code == 401
+
+    def test_expired_token_rejected_401_not_500(self, client, auth_headers):
+        response = client.get("/api/v1/qa-visual/reports", headers=auth_headers["expired"])
+        assert response.status_code == 401
+
+    def test_inactive_user_rejected_403(self, client, auth_headers):
+        response = client.get("/api/v1/qa-visual/reports", headers=auth_headers["dormant"])
+        assert response.status_code in (401, 403)
+
+    def test_admin_access_token_still_sees_all(self, client, auth_headers):
+        body = client.get("/api/v1/qa-visual/reports", headers=auth_headers["admin"]).json()
+        assert len(body) == 3
+
+    def test_refresh_token_on_optional_endpoint_is_anonymous(self, client, auth_headers):
+        """L-1 on get_current_user_optional: a refresh token on the
+        anonymous-friendly feedback endpoint must not authenticate."""
+        response = client.post(
+            "/api/v1/feedback",
+            json={"type": "bug", "title": "x", "description": "y"},
+            headers=auth_headers["alice_refresh"],
+        )
+        assert response.status_code != 500
+        if response.status_code == 201:
+            assert response.json().get("user_id") is None

--- a/dashboard/backend/tests/unit/test_auth_service_token_guards.py
+++ b/dashboard/backend/tests/unit/test_auth_service_token_guards.py
@@ -1,0 +1,165 @@
+"""Token-type and account-status guards for the auth service (cards L-1, L-2, JWT edges).
+
+Security findings hardened here:
+
+- L-1: ``get_current_user`` / ``get_qa_visual_principal`` accepted refresh
+  tokens (7-day expiry) as access tokens because the ``type`` claim was
+  never checked. A leaked refresh token must not grant API access.
+- L-2: ``get_current_user`` did not check ``is_active`` while the refresh
+  and optional paths did — a deactivated user kept full API access until
+  token expiry.
+- JWT edge (a): an expired token must answer 401, never 500.
+- JWT edge (b): a principal with an empty owner must be rejected with a
+  4xx instead of silently scoping reports to an empty owner.
+
+All tests run against the real token minting helpers and a mocked DB
+session (same pattern as tests/unit/test_auth_service.py).
+"""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi import HTTPException
+from jose import jwt
+
+pytest.importorskip("jose")
+
+from models import User
+from services.auth_service import (
+    create_access_token,
+    create_refresh_token,
+    get_current_user,
+    get_current_user_optional,
+    get_qa_visual_principal,
+)
+
+from config import settings
+
+
+def make_user(**overrides) -> User:
+    fields = dict(
+        id=1,
+        username="testuser",
+        email="test@example.com",
+        hashed_password="x",
+        is_active=True,
+        is_superuser=False,
+    )
+    fields.update(overrides)
+    return User(**fields)
+
+
+def make_db(user: User | None) -> AsyncMock:
+    mock_db = AsyncMock()
+    mock_result = AsyncMock()
+    mock_result.scalar_one_or_none = Mock(return_value=user)
+    mock_db.execute = AsyncMock(return_value=mock_result)
+    return mock_db
+
+
+def make_credentials(token: str) -> Mock:
+    mock_credentials = Mock()
+    mock_credentials.credentials = token
+    return mock_credentials
+
+
+def decode(token: str) -> dict:
+    return jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+
+
+class TestTokenTypeGuard:
+    """L-1: refresh tokens must never authenticate access-token endpoints."""
+
+    async def test_refresh_token_rejected_as_access(self):
+        token = create_refresh_token({"sub": "testuser"})
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(make_credentials(token), make_db(make_user()))
+        assert exc_info.value.status_code == 401
+
+    async def test_access_token_carries_type_claim(self):
+        token = create_access_token({"sub": "testuser"})
+        assert decode(token).get("type") == "access"
+
+    async def test_typed_access_token_accepted(self):
+        token = create_access_token({"sub": "testuser"})
+        user = await get_current_user(make_credentials(token), make_db(make_user()))
+        assert user.username == "testuser"
+
+    async def test_legacy_typeless_access_token_accepted(self):
+        """Tokens minted before the type tag stay valid until they expire."""
+        legacy = jwt.encode(
+            {"sub": "testuser", "exp": decode(create_access_token({"sub": "x"}))["exp"]},
+            settings.secret_key,
+            algorithm=settings.algorithm,
+        )
+        user = await get_current_user(make_credentials(legacy), make_db(make_user()))
+        assert user.username == "testuser"
+
+    async def test_unknown_token_type_rejected(self):
+        token = create_access_token({"sub": "testuser"})
+        payload = decode(token)
+        payload["type"] = "password-reset"
+        forged = jwt.encode(payload, settings.secret_key, algorithm=settings.algorithm)
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(make_credentials(forged), make_db(make_user()))
+        assert exc_info.value.status_code == 401
+
+    async def test_optional_auth_treats_refresh_token_as_anonymous(self):
+        token = create_refresh_token({"sub": "testuser"})
+        user = await get_current_user_optional(make_credentials(token), make_db(make_user()))
+        assert user is None
+
+    async def test_optional_auth_accepts_typed_access_token(self):
+        token = create_access_token({"sub": "testuser"})
+        user = await get_current_user_optional(make_credentials(token), make_db(make_user()))
+        assert user is not None
+        assert user.username == "testuser"
+
+
+class TestActiveUserGuard:
+    """L-2: deactivated users must lose API access immediately."""
+
+    async def test_inactive_user_rejected(self):
+        token = create_access_token({"sub": "testuser"})
+        inactive = make_user(is_active=False)
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(make_credentials(token), make_db(inactive))
+        assert exc_info.value.status_code in (401, 403)
+
+    async def test_active_user_still_accepted(self):
+        token = create_access_token({"sub": "testuser"})
+        user = await get_current_user(make_credentials(token), make_db(make_user()))
+        assert user.is_active is True
+
+
+class TestExpiredTokenEdge:
+    """JWT edge (a): expired tokens answer 401, never 500."""
+
+    async def test_expired_token_rejected_401(self):
+        token = create_access_token({"sub": "testuser"}, expires_delta=timedelta(minutes=-5))
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(make_credentials(token), make_db(make_user()))
+        assert exc_info.value.status_code == 401
+
+    async def test_expired_refresh_token_rejected_401(self):
+        token = create_refresh_token({"sub": "testuser"}, expires_delta=timedelta(minutes=-5))
+        from services.auth_service import refresh_access_token
+
+        with pytest.raises(HTTPException) as exc_info:
+            await refresh_access_token(token, make_db(make_user()))
+        assert exc_info.value.status_code == 401
+
+
+class TestPrincipalOwnerEdge:
+    """JWT edge (b): an empty owner identity is rejected with 4xx, not scoped."""
+
+    async def test_empty_username_principal_rejected_4xx(self):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_qa_visual_principal(current_user=make_user(username=""))
+        assert 400 <= exc_info.value.status_code < 500
+
+    async def test_regular_username_principal_still_maps(self):
+        principal = await get_qa_visual_principal(current_user=make_user())
+        assert principal.owner == "testuser"
+        assert principal.is_admin is False

--- a/src/infrastructure/qa_visual/endpoint.py
+++ b/src/infrastructure/qa_visual/endpoint.py
@@ -32,6 +32,7 @@ from src.infrastructure.qa_visual.analyzer import (
     build_trend_report,
 )
 from src.infrastructure.qa_visual.models import AnalyzeResponse, QAVisualPrincipal
+from src.infrastructure.qa_visual.storage import ReportAccessDenied
 
 logger = logging.getLogger(__name__)
 
@@ -52,22 +53,31 @@ def _owner_scope(principal: QAVisualPrincipal | None) -> str | None:
     """Owner a non-admin principal is scoped to; None sees everything."""
     if principal is None or principal.is_admin:
         return None
+    # JWT edge (b): a blank identity must never become a report scope.
+    if not principal.owner or not principal.owner.strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Principal owner must be a non-empty string",
+        )
     return principal.owner
 
 
-def _require_report_access(report: dict, principal: QAVisualPrincipal | None) -> None:
-    """Raise 403 unless the principal owns the report or is an admin.
+def _stamp_owner(principal: QAVisualPrincipal | None) -> str | None:
+    """Owner stamped on newly created reports (analyze).
 
-    S-1R: reports persisted before owner-scoping (owner absent) belong to
-    no regular user, so only admins may read them.
+    Admins without a usable identity produce unowned reports (admin-only
+    reads) instead of reports scoped to a blank owner.
     """
-    if principal is None or principal.is_admin:
-        return
-    if report.get("owner") != principal.owner:
+    if principal is None:
+        return None
+    if not principal.owner or not principal.owner.strip():
+        if principal.is_admin:
+            return None
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Not allowed to access this report",
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Principal owner must be a non-empty string",
         )
+    return principal.owner
 
 
 async def _read_capped(upload: UploadFile) -> bytes:
@@ -171,7 +181,7 @@ def create_qa_visual_router(
             response = await get_analyzer().analyze(
                 image_bytes,
                 target=target,
-                owner=principal.owner if principal else None,
+                owner=_stamp_owner(principal),
             )
         except QAVisualAnalysisError as exc:
             # S-3 (CWE-209): full detail goes to server logs only; the HTTP
@@ -211,13 +221,24 @@ def create_qa_visual_router(
         principal: QAVisualPrincipal | None = Depends(principal_dependency),
     ) -> dict:
         """Return one stored report by id (owner or admin only)."""
-        report = get_analyzer().store.get_report(report_id)
+        try:
+            report = get_analyzer().store.get_report(
+                report_id,
+                owner=_owner_scope(principal),
+                # Standalone mounts (no principal) keep their documented
+                # legacy unscoped behaviour: an explicit privileged read.
+                is_admin=principal is None or principal.is_admin,
+            )
+        except ReportAccessDenied:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not allowed to access this report",
+            )
         if report is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Report '{report_id}' not found",
             )
-        _require_report_access(report, principal)
         return report
 
     @router.get("/trends")

--- a/src/infrastructure/qa_visual/models.py
+++ b/src/infrastructure/qa_visual/models.py
@@ -7,7 +7,7 @@ is prompted to return (validated in Fase A: 5/5 literal texts, 0 hallucinations)
 from datetime import UTC, datetime
 from enum import Enum
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class Severity(str, Enum):
@@ -111,6 +111,16 @@ class QAVisualPrincipal(BaseModel):
 
     owner: str
     is_admin: bool = False
+
+    @field_validator("owner")
+    @classmethod
+    def _owner_not_blank(cls, value: str) -> str:
+        # JWT edge (b): an empty identity must never become a report
+        # scope (empty-owner reports would be readable by empty-owner
+        # principals).
+        if not value or not value.strip():
+            raise ValueError("owner must be a non-empty string")
+        return value
 
 
 class TrendPoint(BaseModel):

--- a/src/infrastructure/qa_visual/storage.py
+++ b/src/infrastructure/qa_visual/storage.py
@@ -31,6 +31,14 @@ def _sanitize_target(target: str) -> str:
     return sanitized or "unknown"
 
 
+class ReportAccessDenied(Exception):
+    """The report exists but is not accessible to the requesting owner (adv-1).
+
+    Raised instead of returning ``None`` so routers can answer 403
+    without a second unscoped lookup leaking report existence.
+    """
+
+
 class QAVisualReportStore:
     """Saves and queries QA Visual reports as JSON files."""
 
@@ -78,12 +86,33 @@ class QAVisualReportStore:
         reports.sort(key=lambda r: r.get("timestamp") or "", reverse=True)
         return reports[:limit] if limit else reports
 
-    def get_report(self, report_id: str) -> dict[str, Any] | None:
-        """Return one report by id, or None."""
+    def get_report(
+        self,
+        report_id: str,
+        owner: str | None = None,
+        is_admin: bool = False,
+    ) -> dict[str, Any] | None:
+        """Return one report by id if the caller may read it (adv-1).
+
+        Fail-closed: callers must state who is asking — an explicit
+        ``owner`` to scope the read, or ``is_admin=True`` to lift the
+        scoping. A call with neither is a programming error, so a new
+        caller can never silently read every tenant's reports.
+
+        Returns ``None`` when no report with that id exists; raises
+        ``ReportAccessDenied`` when it exists but belongs to another
+        owner (legacy unowned reports are admin-only, as everywhere).
+        """
+        if owner is None and not is_admin:
+            raise ValueError(
+                "get_report() requires an explicit owner or is_admin=True (fail-closed)"
+            )
         for path in self._dir.glob("*.json") if self._dir.exists() else []:
             report = self._read_report(path)
             if report and report.get("report_id") == report_id:
-                return report
+                if is_admin or report.get("owner") == owner:
+                    return report
+                raise ReportAccessDenied(report_id)
         return None
 
     def get_baseline(self, target: str, owner: str | None = None) -> dict[str, Any] | None:

--- a/tests/unit/infrastructure/test_qa_visual_analyzer.py
+++ b/tests/unit/infrastructure/test_qa_visual_analyzer.py
@@ -76,7 +76,9 @@ class TestAnalyze:
     @pytest.mark.asyncio
     async def test_report_persisted(self, analyzer, store):
         response = await analyzer.analyze(b"png", target="amc")
-        saved = store.get_report(response.report_id)
+        # analyze() ran without an owner, so the persisted report is
+        # unowned (legacy shape): only an explicit admin read sees it.
+        saved = store.get_report(response.report_id, is_admin=True)
         assert saved is not None
         assert saved["score"] == 95
 

--- a/tests/unit/infrastructure/test_qa_visual_owner_scoping.py
+++ b/tests/unit/infrastructure/test_qa_visual_owner_scoping.py
@@ -142,7 +142,7 @@ class TestAnalyzerOwnerStamping:
         response = await analyzer.analyze(PNG_BYTES, target="amc", owner="alice")
 
         assert response.owner == "alice"
-        persisted = store.get_report(response.report_id)
+        persisted = store.get_report(response.report_id, owner="alice")
         assert persisted["owner"] == "alice"
 
     @pytest.mark.asyncio

--- a/tests/unit/infrastructure/test_qa_visual_storage.py
+++ b/tests/unit/infrastructure/test_qa_visual_storage.py
@@ -82,12 +82,12 @@ class TestListAndGet:
 
     def test_get_by_id(self, store):
         store.save(make_response(report_id="wanted", target="amc"))
-        report = store.get_report("wanted")
+        report = store.get_report("wanted", is_admin=True)
         assert report is not None
         assert report["report_id"] == "wanted"
 
     def test_get_missing_returns_none(self, store):
-        assert store.get_report("nope") is None
+        assert store.get_report("nope", is_admin=True) is None
 
 
 class TestBaseline:

--- a/tests/unit/infrastructure/test_qa_visual_storage_fail_closed.py
+++ b/tests/unit/infrastructure/test_qa_visual_storage_fail_closed.py
@@ -1,0 +1,182 @@
+"""Fail-closed storage access tests for the QA Visual module (adv-1, JWT edge b).
+
+Security finding adv-1: ``QAVisualReportStore.get_report`` took only a
+report id, so authorization lived solely in the endpoint layer — any new
+caller (task, script, future endpoint) could read any tenant's report
+(BOLA). The store now requires the caller's identity up front:
+
+- a bare ``get_report(report_id)`` call raises ``ValueError`` (no open
+  default: state who is asking or pass ``is_admin=True``)
+- an owner-scoped read only returns the owner's own reports
+- a report that exists but belongs to someone else raises
+  ``ReportAccessDenied`` so routers can answer 403 without leaking
+  existence through a second lookup
+- ``is_admin=True`` lifts the scoping explicitly
+
+JWT edge (b): ``QAVisualPrincipal(owner="")`` must never become a report
+scope — the model rejects an empty owner and the router answers 4xx for
+principals that bypass model validation.
+"""
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from src.infrastructure.qa_visual.config import QAVisualConfig
+from src.infrastructure.qa_visual.endpoint import create_qa_visual_router
+from src.infrastructure.qa_visual.models import AnalyzeResponse, QAAnalysis, QAVisualPrincipal
+from src.infrastructure.qa_visual.storage import QAVisualReportStore
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\nfakepngdata"
+
+
+def make_response(report_id: str, owner: str | None, score: int = 95) -> AnalyzeResponse:
+    return AnalyzeResponse(
+        report_id=report_id,
+        target="amc",
+        analysis=QAAnalysis(overall_score=score, summary="seeded"),
+        passed=True,
+        score=score,
+        threshold=80,
+        cost_usd=0.000428,
+        latency_s=4.37,
+        model="deepseek-v4-flash-vision-exp",
+        regression_detected=False,
+        owner=owner,
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> QAVisualReportStore:
+    store = QAVisualReportStore(reports_dir=str(tmp_path / "qa-visual"))
+    store.save(make_response("rep-alice", owner="alice"))
+    store.save(make_response("rep-bob", owner="bob"))
+    store.save(make_response("rep-legacy", owner=None))
+    return store
+
+
+class TestGetReportFailClosed:
+    """adv-1: the store itself enforces who may read a report."""
+
+    def test_bare_call_raises_value_error(self, store):
+        with pytest.raises(ValueError, match="owner"):
+            store.get_report("rep-alice")
+
+    def test_unscoped_call_without_admin_raises_value_error(self, store):
+        with pytest.raises(ValueError, match="is_admin"):
+            store.get_report("rep-alice", owner=None, is_admin=False)
+
+    def test_owner_reads_own_report(self, store):
+        report = store.get_report("rep-alice", owner="alice")
+        assert report is not None
+        assert report["report_id"] == "rep-alice"
+
+    def test_owner_cannot_read_others_report(self, store):
+        from src.infrastructure.qa_visual.storage import ReportAccessDenied
+
+        with pytest.raises(ReportAccessDenied):
+            store.get_report("rep-alice", owner="bob")
+
+    def test_legacy_report_denied_for_regular_owner(self, store):
+        from src.infrastructure.qa_visual.storage import ReportAccessDenied
+
+        with pytest.raises(ReportAccessDenied):
+            store.get_report("rep-legacy", owner="alice")
+
+    def test_admin_reads_any_report(self, store):
+        report = store.get_report("rep-bob", is_admin=True)
+        assert report is not None
+        assert report["owner"] == "bob"
+
+    def test_admin_with_owner_scope_still_reads_any_report(self, store):
+        report = store.get_report("rep-bob", owner="root", is_admin=True)
+        assert report is not None
+
+    def test_missing_report_returns_none_for_owner(self, store):
+        assert store.get_report("missing", owner="alice") is None
+
+    def test_missing_report_returns_none_for_admin(self, store):
+        assert store.get_report("missing", is_admin=True) is None
+
+    def test_bola_guard_still_rejects_after_reseed(self, store, tmp_path):
+        """A second save/lookup round trip keeps the owner scoping."""
+        store.save(make_response("rep-carol", owner="carol"))
+        from src.infrastructure.qa_visual.storage import ReportAccessDenied
+
+        with pytest.raises(ReportAccessDenied):
+            store.get_report("rep-carol", owner="alice")
+
+
+class TestPrincipalOwnerValidation:
+    """JWT edge (b): an empty owner identity is invalid at the model."""
+
+    def test_empty_owner_rejected_by_model(self):
+        with pytest.raises(ValidationError):
+            QAVisualPrincipal(owner="")
+
+    def test_whitespace_owner_rejected_by_model(self):
+        with pytest.raises(ValidationError):
+            QAVisualPrincipal(owner="   ")
+
+    def test_valid_owner_accepted_by_model(self):
+        assert QAVisualPrincipal(owner="alice").owner == "alice"
+
+
+class TestRouterEmptyOwnerGuard:
+    """JWT edge (b): principals bypassing model validation get 4xx."""
+
+    @pytest.fixture
+    def client(self, store):
+        principal_holder = {"principal": None}
+
+        def get_principal():
+            return principal_holder["principal"]
+
+        app = FastAPI()
+        app.include_router(
+            create_qa_visual_router(
+                analyzer=_store_only_analyzer(store), get_current_principal=get_principal
+            )
+        )
+        app.state.principal_holder = principal_holder
+        return TestClient(app)
+
+    def test_empty_owner_principal_gets_4xx_on_reports(self, client, store):
+        client.app.state.principal_holder["principal"] = QAVisualPrincipal.model_construct(owner="")
+        response = client.get("/api/v1/qa-visual/reports")
+        assert 400 <= response.status_code < 500
+
+    def test_empty_owner_principal_gets_4xx_on_single_report(self, client, store):
+        client.app.state.principal_holder["principal"] = QAVisualPrincipal.model_construct(owner="")
+        response = client.get("/api/v1/qa-visual/reports/rep-alice")
+        assert 400 <= response.status_code < 500
+
+    def test_empty_owner_principal_gets_4xx_on_analyze(self, client, store):
+        client.app.state.principal_holder["principal"] = QAVisualPrincipal.model_construct(owner="")
+        response = client.post(
+            "/api/v1/qa-visual/analyze",
+            files={"screenshot": ("page.png", PNG_BYTES, "image/png")},
+            data={"target": "amc"},
+        )
+        assert 400 <= response.status_code < 500
+
+    def test_empty_owner_admin_bypasses_guard_on_reads(self, client, store):
+        """An admin principal does not need a usable owner for reads."""
+        client.app.state.principal_holder["principal"] = QAVisualPrincipal.model_construct(
+            owner="", is_admin=True
+        )
+        response = client.get("/api/v1/qa-visual/reports")
+        assert response.status_code == 200
+
+
+def _store_only_analyzer(store: QAVisualReportStore):
+    """Analyzer stub whose only job is serving the seeded store."""
+    from src.infrastructure.qa_visual.analyzer import QAVisualAnalyzer
+
+    analyzer = QAVisualAnalyzer.__new__(QAVisualAnalyzer)
+    analyzer._config = QAVisualConfig()
+    analyzer._store = store
+    return analyzer


### PR DESCRIPTION
## Objetivo

Hardening de la superficie de autenticación/autorización de QA Visual según los hallazgos L-1, L-2, adv-1 y los dos bordes JWT de la card 86464839. TDD estricto RED→GREEN→REFACTOR; matriz de regresión auth completa en root + dashboard; 0 regresiones (fallos preexistentes verificados idénticos contra bfb388a prístino).

## Qué se hizo (What was done)

- **L-1 — token type**: `get_current_user` ahora rechaza refresh tokens como access (claim `type` debe ser ausente o `access`); `create_access_token` emite `type=access`; `get_current_user_optional` aplica la misma regla (refresh = anónimo).
- **L-2 — is_active**: `get_current_user` rechaza cuentas desactivadas con 403 inmediato (antes solo refresh/optional lo comprobaban).
- **adv-1 — fail-closed storage**: `QAVisualReportStore.get_report` exige identidad explícita (`owner` o `is_admin=True`); llamada bare → `ValueError`; report ajeno existente → `ReportAccessDenied` (router responde 403). La authz ya no vive solo en la capa de endpoint (guard BOLA). Aplicado a ambas copias del módulo (root + vendor dashboard, vendor-parity test verde).
- **JWT edge (a)**: token expirado → 401 nunca 500 (`ExpiredSignatureError ⊂ JWTError`), testeado en access y refresh.
- **JWT edge (b)**: `QAVisualPrincipal(owner="")` inválido en el modelo (`field_validator`), router responde 422 ante principals blank que bypassean validación, y `get_qa_visual_principal` (dashboard) rechaza usernames no usables con 422. `analyze` con admin sin identidad estampa report unowned en vez de blank-owner.

## Dónde están los artefactos (Where)

| Fichero | Cambio |
|---|---|
| `dashboard/backend/services/auth_service.py` | L-1 type check, L-2 is_active, guard 422 en `get_qa_visual_principal` |
| `src/infrastructure/qa_visual/storage.py` + copia dashboard | `ReportAccessDenied` + `get_report` fail-closed (adv-1) |
| `src/infrastructure/qa_visual/models.py` + copia dashboard | `field_validator` owner no-blank (edge b) |
| `src/infrastructure/qa_visual/endpoint.py` + copia dashboard | lectura scoped + 403, guards 422, `_stamp_owner` |
| `tests/unit/infrastructure/test_qa_visual_storage_fail_closed.py` | matriz fail-closed root (17 tests) |
| `dashboard/backend/tests/infrastructure/test_qa_visual_storage_fail_closed.py` | matriz fail-closed copia dashboard |
| `dashboard/backend/tests/unit/test_auth_service_token_guards.py` | guards L-1/L-2/edges a nivel unit |
| `dashboard/backend/tests/test_qa_visual_owner_scoping.py` | matriz E2E real-app: access/refresh/expired/inactive/admin/optional |
| `CHANGELOG.md` | entrada Security |

## Cómo verificar (How to verify)

```bash
# Root (CI corre esto): 762 passed
python3 -m pytest tests/unit -q

# Dashboard auth + qa-visual + middleware
cd dashboard/backend
python3 -m pytest tests/unit tests/test_qa_visual_owner_scoping.py tests/infrastructure/test_qa_visual_storage_fail_closed.py tests/middleware -q --no-cov
# → 96 passed aprox (nuevos + existentes)

# Style gates (pins pyproject)
black --check src tests && ruff check src tests && isort --check-only src tests

# Matriz auth E2E específica
python3 -m pytest tests/test_qa_visual_owner_scoping.py::TestAuthHardeningMatrix -v --no-cov
```

RED verificado antes de cada fix: refresh-as-access devolvía **200** en el árbol sin fix (vulnerabilidad confirmada), inactive **200**, `get_report` bare devolvía cualquier report.

## Problemas conocidos (Known issues)

- **Preexistentes en main (NO introducidos aquí, verificados idénticos contra bfb388a)**: `tests/infrastructure/test_test_cache*.py` (17F/16E, mocks Redis) y `tests/services/test_bulk_service.py` en dashboard; `tests/security` + `tests/integration` del root requieren servicios vivos (64F/31E también en prístino). La CI de PR solo corre `tests/unit`.
- `middleware/rate_limit.py` intocable (card DevOps 4f9fb443) — NO modificado.
- Tokens access emitidos antes del despliegue (sin claim `type`) siguen válidos hasta su expiración (minutos) por compatibilidad deliberada.

## Siguiente (What's next)

- Gates de pipeline pendientes: Reviewer + Security + QA + Alfred Review (toca auth → pipeline completo). NO merge desde esta card.
- Follow-up sugerido: los 17F/16E preexistentes de dashboard cache/bulk merecen card propia.
- CI: 6/6 esperado; si Trivy falla por mirror.gcr.io BLOB_UNKNOWN = transient conocido → 1 re-run.