### PR TITLE
feat(accuracy): real LLM gateway response provider for POST /accuracy/sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Accuracy response provider (card 2f9afe89)**: real
+  `IResponseProvider` implementation (`LLMGatewayResponseProvider`)
+  backed by an OpenAI-compatible LLM gateway, so `POST
+  /accuracy/sessions` returns 200 with a provider configured instead of
+  503. Deploy config via `ACCURACY_PROVIDER_API_KEY` (fallback
+  `OPENCODE_GO_API_KEY`) plus optional `ACCURACY_PROVIDER_BASE_URL`,
+  `ACCURACY_PROVIDER_MODEL`, `ACCURACY_PROVIDER_TIMEOUT_S`,
+  `ACCURACY_PROVIDER_MAX_TOKENS`; no key → provider stays off and the
+  explicit 503 remains (fail-closed by omission). Injectable HTTP client
+  keeps unit tests network-free; provider failures map to 502 with a
+  sanitized detail (CWE-209). Vendored copy synced (vendor-parity test)
+  and wired in `dashboard/backend/main.py`. Docs in
+  `docs/accuracy-testing.md`.
 - **Accuracy testing API wiring (card c9825844)**: the accuracy_testing
   module (merged from cards 72f97f1b/ca3090d5) is mounted in the dashboard
   backend behind JWT auth, opt-in via `ACCURACY_TESTING_ENABLED=1` with

--- a/dashboard/backend/main.py
+++ b/dashboard/backend/main.py
@@ -85,8 +85,14 @@ if os.getenv("QA_VISUAL_ENABLED") == "1":
 # contracts: L-1 per-tenant salt derived server-side (ACCURACY_SPLIT_SECRET,
 # required — the router factory fails closed on an empty secret) and L-2
 # owner-scoped resources with to_dict_full() served to superusers only.
+# Response provider (card 2f9afe89): built from env; None when no API key
+# is configured, which keeps POST /accuracy/sessions at its explicit 503
+# "no provider configured" signal (fail-closed by omission).
 if os.getenv("ACCURACY_TESTING_ENABLED") == "1":
     from src.infrastructure.accuracy_testing.endpoint import create_accuracy_router
+    from src.infrastructure.accuracy_testing.llm_gateway_provider import (
+        create_response_provider_from_env,
+    )
     from src.infrastructure.accuracy_testing.security import AccuracyPrincipal
 
     def _accuracy_principal(user: User = Depends(get_current_user)) -> AccuracyPrincipal:
@@ -98,6 +104,7 @@ if os.getenv("ACCURACY_TESTING_ENABLED") == "1":
     app.include_router(
         create_accuracy_router(
             principal_dependency=_accuracy_principal,
+            response_provider=create_response_provider_from_env(),
             split_secret=os.getenv("ACCURACY_SPLIT_SECRET", ""),
         )
     )

--- a/dashboard/backend/src/infrastructure/accuracy_testing/__init__.py
+++ b/dashboard/backend/src/infrastructure/accuracy_testing/__init__.py
@@ -4,6 +4,11 @@ Infrastructure for AI Accuracy Testing
 
 from .endpoint import create_accuracy_router
 from .german_ai_liability_benchmarks import create_german_ai_liability_benchmarks
+from .llm_gateway_provider import (
+    LLMGatewayProviderError,
+    LLMGatewayResponseProvider,
+    create_response_provider_from_env,
+)
 from .rule_based_evaluator import RuleBasedAccuracyEvaluator
 from .security import AccuracyPrincipal, derive_tenant_salt
 from .session_store import AccuracySessionStore, run_accuracy_session, split_for_tenant
@@ -11,9 +16,12 @@ from .session_store import AccuracySessionStore, run_accuracy_session, split_for
 __all__ = [
     "AccuracyPrincipal",
     "AccuracySessionStore",
+    "LLMGatewayProviderError",
+    "LLMGatewayResponseProvider",
     "RuleBasedAccuracyEvaluator",
     "create_accuracy_router",
     "create_german_ai_liability_benchmarks",
+    "create_response_provider_from_env",
     "derive_tenant_salt",
     "run_accuracy_session",
     "split_for_tenant",

--- a/dashboard/backend/src/infrastructure/accuracy_testing/endpoint.py
+++ b/dashboard/backend/src/infrastructure/accuracy_testing/endpoint.py
@@ -33,6 +33,7 @@ Example:
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -44,6 +45,7 @@ from src.domain.accuracy_testing.splitting import BenchmarkSplit
 from src.infrastructure.accuracy_testing.german_ai_liability_benchmarks import (
     create_german_ai_liability_benchmarks,
 )
+from src.infrastructure.accuracy_testing.llm_gateway_provider import LLMGatewayProviderError
 from src.infrastructure.accuracy_testing.rule_based_evaluator import RuleBasedAccuracyEvaluator
 from src.infrastructure.accuracy_testing.security import AccuracyPrincipal
 from src.infrastructure.accuracy_testing.session_store import (
@@ -51,6 +53,8 @@ from src.infrastructure.accuracy_testing.session_store import (
     run_accuracy_session,
     split_for_tenant,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class SessionCreateRequest(BaseModel):
@@ -175,14 +179,23 @@ def create_accuracy_router(
             else _restrict_split(split, set(request.benchmark_ids))
         )
 
-        session = run_accuracy_session(
-            benchmarks=selected,
-            split=session_split,
-            evaluator=evaluator,
-            response_provider=response_provider,
-            ai_model=request.ai_model,
-            tenant_id=principal.owner,
-        )
+        try:
+            session = run_accuracy_session(
+                benchmarks=selected,
+                split=session_split,
+                evaluator=evaluator,
+                response_provider=response_provider,
+                ai_model=request.ai_model,
+                tenant_id=principal.owner,
+            )
+        except LLMGatewayProviderError as exc:
+            # CWE-209: generic detail only; the provider error (and the
+            # upstream body it logged) never reaches the HTTP client.
+            logger.error("Accuracy response provider failed: %s", exc)
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Response provider unavailable; see server logs",
+            ) from exc
         store.save(principal.owner, session, session_split)
         return _session_view(session, session_split)
 

--- a/dashboard/backend/src/infrastructure/accuracy_testing/llm_gateway_provider.py
+++ b/dashboard/backend/src/infrastructure/accuracy_testing/llm_gateway_provider.py
@@ -1,0 +1,188 @@
+"""Real IResponseProvider backed by an OpenAI-compatible LLM gateway.
+
+Card 2f9afe89: POST /accuracy/sessions needs actual AI responses to
+measure accuracy. This provider talks to the same gateway family as
+``qa_visual`` (OpenAI-compatible chat completions, Bearer auth, browser
+User-Agent against Cloudflare 1010) — pattern, not shared code.
+
+Design notes:
+
+- SYNC on purpose: ``IResponseProvider.get_response`` is a sync protocol
+  and the accuracy endpoints are sync handlers (FastAPI runs them in a
+  threadpool). Making the protocol async would ripple through the domain
+  layer for no benefit at this catalog size.
+- Injectable HTTP client: unit tests pass an ``httpx.Client`` with a
+  ``MockTransport`` so no test ever touches the network.
+- Fail-closed by omission: ``create_response_provider_from_env`` returns
+  ``None`` when no API key is configured, so the endpoint keeps its
+  explicit 503 "not configured" signal instead of half-working.
+- CWE-209 / S-3: upstream bodies are logged server-side only; the raised
+  error message carries the status/category, never the body.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+
+from src.domain.accuracy_testing.interfaces import IResponseProvider
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://opencode.ai/zen/go/v1/chat/completions"
+DEFAULT_MODEL = "deepseek-v4-flash-vision-exp"
+DEFAULT_TIMEOUT_S = 60.0
+DEFAULT_MAX_TOKENS = 1024
+
+# Browser UA required to avoid Cloudflare 1010 rejections (qa_visual C3).
+BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+)
+
+# Neutral persona: the model under test answers the benchmark question as
+# itself. The provider never receives ground truth (the session store only
+# forwards ``benchmark.question``), so no evaluation leakage is possible.
+SYSTEM_PROMPT = (
+    "You are a legal information assistant. Answer the user's question concisely and accurately."
+)
+
+
+class LLMGatewayProviderError(RuntimeError):
+    """Raised when the LLM gateway call fails or returns an unusable body.
+
+    The message is sanitized (status/category only) so it can safely cross
+    the API boundary; upstream bodies stay in server logs.
+    """
+
+
+class LLMGatewayResponseProvider(IResponseProvider):
+    """``IResponseProvider`` implementation calling an LLM gateway.
+
+    Args:
+        api_key: gateway credentials (env-only in production, never committed).
+        base_url: OpenAI-compatible chat completions endpoint.
+        model: default model id under test.
+        timeout_s: per-request timeout in seconds.
+        max_tokens: completion cap.
+        http_client: injectable ``httpx.Client`` (tests use ``MockTransport``);
+            when omitted, a client is created with ``timeout_s``.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = DEFAULT_BASE_URL,
+        model: str = DEFAULT_MODEL,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        self.api_key = api_key
+        self.base_url = base_url
+        self.model = model
+        self.timeout_s = timeout_s
+        self.max_tokens = max_tokens
+        self._owns_client = http_client is None
+        self._client = http_client or httpx.Client(timeout=timeout_s)
+
+    def get_response(self, prompt: str, model: str = "") -> str:
+        """Fetch an AI response for ``prompt`` (``model`` overrides the
+        configured default for this call)."""
+        if not self.api_key:
+            raise LLMGatewayProviderError(
+                "API key missing: set ACCURACY_PROVIDER_API_KEY in the environment"
+            )
+
+        payload = {
+            "model": model or self.model,
+            "messages": [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            "max_tokens": self.max_tokens,
+            "temperature": 0.1,
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": BROWSER_USER_AGENT,
+        }
+
+        try:
+            response = self._client.post(self.base_url, json=payload, headers=headers)
+        except httpx.TimeoutException as exc:
+            raise LLMGatewayProviderError(f"Gateway timeout: {type(exc).__name__}") from exc
+        except httpx.HTTPError as exc:
+            raise LLMGatewayProviderError("Gateway connection error") from exc
+
+        if response.status_code != 200:
+            # CWE-209 (S-3): upstream body stays in server logs only.
+            logger.error(
+                "Accuracy LLM gateway HTTP %s: %s",
+                response.status_code,
+                response.text[:200],
+            )
+            raise LLMGatewayProviderError(f"Gateway HTTP {response.status_code}")
+
+        try:
+            body = response.json()
+            content = body["choices"][0]["message"]["content"]
+        except (ValueError, KeyError, IndexError, TypeError) as exc:
+            raise LLMGatewayProviderError(
+                f"Malformed gateway response: {type(exc).__name__}"
+            ) from exc
+        if not isinstance(content, str):
+            # null/non-string content breaks the -> str contract; "" is the
+            # only acceptable empty answer (measurable by the evaluator).
+            raise LLMGatewayProviderError("Malformed gateway response: non-string content")
+
+        # An empty completion is a measurable bad answer, not a transport
+        # error: return it verbatim and let the evaluator score it.
+        return content
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name, "")
+    try:
+        return float(raw) if raw else default
+    except ValueError:
+        logger.warning("Invalid %s=%r; falling back to %s", name, raw, default)
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "")
+    try:
+        return int(raw) if raw else default
+    except ValueError:
+        logger.warning("Invalid %s=%r; falling back to %s", name, raw, default)
+        return default
+
+
+def create_response_provider_from_env() -> LLMGatewayResponseProvider | None:
+    """Build the provider from deploy env vars.
+
+    Returns ``None`` when no API key is configured (checked in order:
+    ``ACCURACY_PROVIDER_API_KEY``, then the repo-wide ``OPENCODE_GO_API_KEY``),
+    keeping POST /accuracy/sessions at its explicit 503 "not configured".
+    """
+    api_key = (
+        os.environ.get("ACCURACY_PROVIDER_API_KEY") or os.environ.get("OPENCODE_GO_API_KEY") or ""
+    ).strip()
+    if not api_key:
+        return None
+
+    return LLMGatewayResponseProvider(
+        api_key=api_key,
+        base_url=os.environ.get("ACCURACY_PROVIDER_BASE_URL", DEFAULT_BASE_URL),
+        model=os.environ.get("ACCURACY_PROVIDER_MODEL", DEFAULT_MODEL),
+        timeout_s=_env_float("ACCURACY_PROVIDER_TIMEOUT_S", DEFAULT_TIMEOUT_S),
+        max_tokens=_env_int("ACCURACY_PROVIDER_MAX_TOKENS", DEFAULT_MAX_TOKENS),
+    )

--- a/dashboard/backend/tests/test_accuracy_wiring.py
+++ b/dashboard/backend/tests/test_accuracy_wiring.py
@@ -93,6 +93,46 @@ def test_accuracy_mount_fails_closed_without_secret():
     mp.undo()
 
 
+@pytest.fixture()
+def main_app_mounted_with_provider():
+    mp = pytest.MonkeyPatch()
+    mp.setenv("ACCURACY_TESTING_ENABLED", "1")
+    mp.setenv("ACCURACY_SPLIT_SECRET", "wiring-test-secret")
+    mp.setenv("ACCURACY_PROVIDER_API_KEY", "wiring-test-key")
+    import main as dashboard_main
+
+    app = importlib.reload(dashboard_main).app
+    yield app
+    mp.undo()
+
+
+def test_accuracy_mount_with_provider_env_assembles(main_app_mounted_with_provider):
+    """Card 2f9afe89: with a provider API key in the env the dashboard
+    mounts cleanly with the response provider wired (no import/mount error;
+    auth still gates the endpoints)."""
+    client = TestClient(main_app_mounted_with_provider)
+    # Mounted (not 404) and still auth-gated.
+    assert client.get("/accuracy/benchmarks").status_code == 401
+    resp = client.post("/accuracy/sessions", json={"ai_model": "m"})
+    assert resp.status_code == 401
+    # Not the provider-less 503: the request never reached the handler
+    # because auth rejects it first, proving the router (and provider
+    # import) assembled without error.
+    assert resp.status_code != 503
+
+
+def test_vendored_factory_returns_none_without_key(monkeypatch):
+    """The vendored copy exposes the env factory and honours fail-closed
+    by omission: no key -> None (endpoint keeps its explicit 503)."""
+    from src.infrastructure.accuracy_testing.llm_gateway_provider import (
+        create_response_provider_from_env,
+    )
+
+    monkeypatch.delenv("ACCURACY_PROVIDER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENCODE_GO_API_KEY", raising=False)
+    assert create_response_provider_from_env() is None
+
+
 def test_vendored_router_happy_path_owner_scoped():
     app = FastAPI()
     app.include_router(

--- a/docs/accuracy-testing.md
+++ b/docs/accuracy-testing.md
@@ -69,12 +69,64 @@ question/ground-truth string or forbidden key appears in any response.
 backwards compatibility; the rule-based evaluator always threads the
 benchmark's own threshold).
 
+## Response provider (card 2f9afe89)
+
+`POST /accuracy/sessions` needs actual AI responses. The real provider —
+`LLMGatewayResponseProvider` — calls an OpenAI-compatible chat
+completions gateway (same gateway family as `qa_visual`, pattern not
+shared code):
+
+- **Sync by design**: `IResponseProvider.get_response` is a sync
+  protocol and the endpoints are sync handlers (FastAPI threadpool).
+- **Injectable HTTP client**: unit tests pass an `httpx.Client` with a
+  `MockTransport`; no test touches the network.
+- **No leakage**: the provider only ever receives `benchmark.question`
+  (never ground truth), forwarded as-is with a neutral legal-assistant
+  system prompt.
+- **Fail-closed by omission**: `create_response_provider_from_env()`
+  returns `None` when no API key is configured, so POST /sessions keeps
+  its explicit 503 "no provider configured" signal.
+- **Error semantics**: gateway failures raise `LLMGatewayProviderError`
+  with a sanitized message (status/category only — upstream bodies go
+  to server logs, CWE-209); the endpoint maps it to **502 Bad Gateway**
+  with a generic detail. An empty completion (`""`) is returned verbatim
+  as a measurable bad answer.
+
 ## Configuration
 
 | Variable | Default | Description |
 |---|---|---|
 | `ACCURACY_TESTING_ENABLED` | unset | Opt-in mount of the accuracy router (dashboard backend) |
 | `ACCURACY_SPLIT_SECRET` | — | Platform secret for per-tenant salt derivation (required when enabled) |
+| `ACCURACY_PROVIDER_API_KEY` | fallback `OPENCODE_GO_API_KEY` | LLM gateway key; absent key → provider stays off → 503 |
+| `ACCURACY_PROVIDER_BASE_URL` | `https://opencode.ai/zen/go/v1/chat/completions` | OpenAI-compatible chat completions endpoint |
+| `ACCURACY_PROVIDER_MODEL` | `deepseek-v4-flash-vision-exp` | Model id under test (overridable per session via `ai_model`) |
+| `ACCURACY_PROVIDER_TIMEOUT_S` | `60` | Per-request timeout in seconds (invalid values fall back) |
+| `ACCURACY_PROVIDER_MAX_TOKENS` | `1024` | Completion cap |
+
+## Trying it out
+
+Deploy env (dashboard backend):
+
+```bash
+export ACCURACY_TESTING_ENABLED=1
+export ACCURACY_SPLIT_SECRET="<platform-secret>"
+export ACCURACY_PROVIDER_API_KEY="<gateway-key>"   # or OPENCODE_GO_API_KEY
+# optional overrides:
+# ACCURACY_PROVIDER_MODEL, ACCURACY_PROVIDER_BASE_URL,
+# ACCURACY_PROVIDER_TIMEOUT_S, ACCURACY_PROVIDER_MAX_TOKENS
+```
+
+Run a session (auth is the dashboard JWT):
+
+```bash
+curl -X POST http://localhost:8000/accuracy/sessions \
+  -H "Authorization: Bearer $DASHBOARD_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"ai_model": ""}'
+# 200 -> {"id": "...", "evaluations": [...], "holdout_summary": {...}, "split": {...}}
+# 502 -> gateway failed (see server logs) | 503 -> no provider configured
+```
 
 ## REST API
 

--- a/docs/plans/2026-08-24-accuracy-response-provider-plan.md
+++ b/docs/plans/2026-08-24-accuracy-response-provider-plan.md
@@ -1,0 +1,52 @@
+# Accuracy Response Provider — Implementation Plan (card 2f9afe89)
+
+Design: `docs/specs/2026-08-24-accuracy-response-provider-design.md`
+
+## Tasks (TDD: RED → GREEN → REFACTOR per task)
+
+1. **RED** — `tests/unit/infrastructure/test_llm_gateway_provider.py`
+   - `TestRequestContract`: OpenAI payload (model, system+user messages,
+     temperature, max_tokens), Bearer header, browser UA, target URL.
+   - `TestGetResponse`: returns `choices[0].message.content`.
+   - `TestModelOverride`: per-call `model` wins over configured model.
+   - `TestErrorMapping`: HTTP >= 400, timeout, connect error, malformed
+     JSON, empty choices → `LLMGatewayProviderError` with sanitized
+     message (no upstream body).
+   - `TestFactory`: env matrix (no key → None; provider key; fallback
+     `OPENCODE_GO_API_KEY`; URL/model/timeout overrides; invalid
+     timeout → default).
+2. **RED** — endpoint contract extension: provider failure → 502 with
+   generic detail; canary: upstream body absent from response.
+3. **RED** — provider+endpoint integration (DI): router built with a
+   factory-configured provider + injected MockTransport → POST 200.
+4. **GREEN** — implement `src/infrastructure/accuracy_testing/llm_gateway_provider.py`
+   (error, provider, factory) + 502 mapping in `endpoint.py` +
+   `__init__.py` exports.
+5. **Vendor sync** — copy `src/infrastructure/accuracy_testing/*.py` →
+   `dashboard/backend/src/infrastructure/accuracy_testing/`; wire
+   `response_provider=create_response_provider_from_env()` in
+   `dashboard/backend/main.py`; extend
+   `dashboard/backend/tests/test_accuracy_wiring.py` (reload with
+   provider env → clean assembly).
+6. **REFACTOR** — style pass (ruff/black, line length 100), no behavior
+   change; all tests green; coverage ≥ 80% on the new file.
+7. **Docs** — `docs/accuracy-testing.md`: provider section + env table
+   + curl example; CHANGELOG entry.
+8. **Ship** — conventional commits, push, PR with AC summary.
+
+## Acceptance criteria mapping
+
+| AC | Proof |
+|---|---|
+| 1. POST 200 with provider | integration test (task 3) + wiring test (task 5) |
+| 2. Injectable provider, unit tests sin red | MockTransport DI (tasks 1–3) |
+| 3. E2E left to qa-tester | endpoint functional + curl recipe in docs |
+| 4. Docs | task 7 |
+
+## Risks
+
+- Vendored drift → mitigated by the vendor-parity test (fails loudly).
+- Gateway latency in POST → bounded by `ACCURACY_PROVIDER_TIMEOUT_S`,
+  failures map to 502 instead of hanging or leaking 500s.
+- Secret hygiene → key read only from env, never logged, never
+  committed (same rule as `OPENCODE_GO_API_KEY`).

--- a/docs/specs/2026-08-24-accuracy-response-provider-design.md
+++ b/docs/specs/2026-08-24-accuracy-response-provider-design.md
@@ -1,0 +1,120 @@
+# Accuracy Response Provider — Design (card 2f9afe89)
+
+Date: 2026-08-24
+Branch: `feat/accuracy-response-provider` (base `origin/main` bfb388a)
+
+## Problem
+
+`POST /accuracy/sessions` returns **503** because the dashboard mount
+(`dashboard/backend/main.py`) never passes a `response_provider` to
+`create_accuracy_router`. The evaluation pipeline (split → eval → sealed
+holdout) is complete and tested, but there is no real implementation of
+`IResponseProvider` that fetches actual AI responses.
+
+## Approaches considered
+
+### A. Sync LLM gateway provider (OpenAI-compatible) + env factory — SELECTED
+
+A new `LLMGatewayResponseProvider` implements the existing **sync**
+`IResponseProvider` protocol with a sync `httpx.Client`, following the
+proven gateway pattern of `qa_visual/gateway_client.py` (same
+OpenAI-compatible chat-completions endpoint, Bearer auth, browser UA,
+sanitized errors per CWE-209/S-3) **without touching qa_visual**.
+
+- Pros: real AI responses (the point of accuracy testing); DI intact —
+  the constructor accepts an injectable HTTP client for network-free
+  unit tests; zero domain changes (protocol stays sync); vendor sync is
+  a file copy; deploy via env vars like every other module flag.
+- Cons: introduces a network call in the POST request path — inherent
+  to a real provider; mitigated with timeout + explicit 502 mapping.
+
+### B. Deterministic rule-based provider — REJECTED
+
+Canned/stub answers would make the "accuracy" measurement meaningless:
+it would evaluate a constant string, not an AI system. The card asks
+for a real provider.
+
+### C. Async refactor of `IResponseProvider` — REJECTED (deferred)
+
+Changing the protocol to async ripples through `session_store`,
+`holdout_service`, the vendored copy and every existing test. The
+benchmark catalog is small (tens of items) and FastAPI already runs
+sync endpoints in a threadpool, so sync is adequate here.
+
+## Selected design
+
+### New file: `src/infrastructure/accuracy_testing/llm_gateway_provider.py`
+
+1. `LLMGatewayProviderError(RuntimeError)` — message is always
+   sanitized (status/category only). Upstream bodies are logged
+   server-side, never raised into HTTP responses (CWE-209).
+2. `LLMGatewayResponseProvider` — implements `IResponseProvider`:
+   - `__init__(api_key, base_url=..., model=..., timeout_s=..., max_tokens=..., http_client=None)`.
+     The optional `http_client` keeps unit tests network-free (same DI
+     pattern as `VisionGatewayClient`).
+   - `get_response(prompt, model="") -> str` — POST
+     `{"model": model or configured, "messages": [system, user], "temperature": 0.1, "max_tokens": ...}`.
+     The system prompt is a neutral legal-assistant persona; the
+     benchmark question is forwarded as-is. The provider NEVER sees
+     ground truth (the session store only passes `benchmark.question`),
+     so no evaluation leakage is possible.
+   - Browser `User-Agent` (Cloudflare 1010 mitigation, same as qa_visual C3).
+   - `close()` for resource hygiene.
+3. `create_response_provider_from_env() -> LLMGatewayResponseProvider | None` —
+   returns `None` when no API key is configured, so the existing 503
+   stays as the explicit "not configured" signal (fail-closed by
+   omission, mirrors `QA_VISUAL_ENABLED` opt-in style).
+
+### Endpoint mapping (`endpoint.py`)
+
+`LLMGatewayProviderError` raised during `run_accuracy_session` maps to
+**502 Bad Gateway** with a generic detail. All other semantics
+untouched.
+
+### Wiring (`dashboard/backend/main.py`)
+
+```python
+response_provider=create_response_provider_from_env(),
+```
+
+added to the existing `create_accuracy_router(...)` mount behind
+`ACCURACY_TESTING_ENABLED=1`.
+
+### Vendored copy
+
+Copy `src/infrastructure/accuracy_testing/*.py` to
+`dashboard/backend/src/infrastructure/accuracy_testing/` — enforced by
+`tests/unit/infrastructure/test_accuracy_vendor_parity.py`.
+
+## Configuration (deploy)
+
+| Variable | Default | Description |
+|---|---|---|
+| `ACCURACY_PROVIDER_API_KEY` | fallback `OPENCODE_GO_API_KEY` | Gateway key; absent key → provider stays `None` → 503 |
+| `ACCURACY_PROVIDER_BASE_URL` | `https://opencode.ai/zen/go/v1/chat/completions` | OpenAI-compatible endpoint (same gateway family as qa_visual) |
+| `ACCURACY_PROVIDER_MODEL` | `deepseek-v4-flash-vision-exp` | Model id under test |
+| `ACCURACY_PROVIDER_TIMEOUT_S` | `60` | Per-request timeout (robust parse, falls back on invalid) |
+| `ACCURACY_PROVIDER_MAX_TOKENS` | `1024` | Completion cap |
+
+## Testing strategy (TDD)
+
+- Unit (`tests/unit/infrastructure/test_llm_gateway_provider.py`):
+  request contract (payload/headers/URL), happy path, per-call model
+  override, sanitized error mapping (HTTP error, timeout, connection
+  error, malformed JSON, empty choices), factory env matrix — all via
+  `httpx.MockTransport`, zero network.
+- Endpoint contract (`tests/unit/api/test_accuracy_endpoint_contracts.py`):
+  provider failure → 502, upstream body never reaches the client.
+- Provider+endpoint integration via DI: router + real provider +
+  MockTransport → `POST /accuracy/sessions` **200** (AC1 proof,
+  network-free).
+- Dashboard wiring: module reload with provider env set assembles the
+  app cleanly (mount still fail-closed without the split secret).
+- Coverage ≥ 80% on the new module file.
+
+## Out of scope
+
+- Async provider protocol (approach C).
+- LLM-based evaluator (rule-based evaluator stays).
+- `qa_visual` module and dashboard middleware/rate_limit (forbidden by
+  the card).

--- a/src/infrastructure/accuracy_testing/__init__.py
+++ b/src/infrastructure/accuracy_testing/__init__.py
@@ -4,6 +4,11 @@ Infrastructure for AI Accuracy Testing
 
 from .endpoint import create_accuracy_router
 from .german_ai_liability_benchmarks import create_german_ai_liability_benchmarks
+from .llm_gateway_provider import (
+    LLMGatewayProviderError,
+    LLMGatewayResponseProvider,
+    create_response_provider_from_env,
+)
 from .rule_based_evaluator import RuleBasedAccuracyEvaluator
 from .security import AccuracyPrincipal, derive_tenant_salt
 from .session_store import AccuracySessionStore, run_accuracy_session, split_for_tenant
@@ -11,9 +16,12 @@ from .session_store import AccuracySessionStore, run_accuracy_session, split_for
 __all__ = [
     "AccuracyPrincipal",
     "AccuracySessionStore",
+    "LLMGatewayProviderError",
+    "LLMGatewayResponseProvider",
     "RuleBasedAccuracyEvaluator",
     "create_accuracy_router",
     "create_german_ai_liability_benchmarks",
+    "create_response_provider_from_env",
     "derive_tenant_salt",
     "run_accuracy_session",
     "split_for_tenant",

--- a/src/infrastructure/accuracy_testing/endpoint.py
+++ b/src/infrastructure/accuracy_testing/endpoint.py
@@ -33,6 +33,7 @@ Example:
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -44,6 +45,7 @@ from src.domain.accuracy_testing.splitting import BenchmarkSplit
 from src.infrastructure.accuracy_testing.german_ai_liability_benchmarks import (
     create_german_ai_liability_benchmarks,
 )
+from src.infrastructure.accuracy_testing.llm_gateway_provider import LLMGatewayProviderError
 from src.infrastructure.accuracy_testing.rule_based_evaluator import RuleBasedAccuracyEvaluator
 from src.infrastructure.accuracy_testing.security import AccuracyPrincipal
 from src.infrastructure.accuracy_testing.session_store import (
@@ -51,6 +53,8 @@ from src.infrastructure.accuracy_testing.session_store import (
     run_accuracy_session,
     split_for_tenant,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class SessionCreateRequest(BaseModel):
@@ -175,14 +179,23 @@ def create_accuracy_router(
             else _restrict_split(split, set(request.benchmark_ids))
         )
 
-        session = run_accuracy_session(
-            benchmarks=selected,
-            split=session_split,
-            evaluator=evaluator,
-            response_provider=response_provider,
-            ai_model=request.ai_model,
-            tenant_id=principal.owner,
-        )
+        try:
+            session = run_accuracy_session(
+                benchmarks=selected,
+                split=session_split,
+                evaluator=evaluator,
+                response_provider=response_provider,
+                ai_model=request.ai_model,
+                tenant_id=principal.owner,
+            )
+        except LLMGatewayProviderError as exc:
+            # CWE-209: generic detail only; the provider error (and the
+            # upstream body it logged) never reaches the HTTP client.
+            logger.error("Accuracy response provider failed: %s", exc)
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Response provider unavailable; see server logs",
+            ) from exc
         store.save(principal.owner, session, session_split)
         return _session_view(session, session_split)
 

--- a/src/infrastructure/accuracy_testing/llm_gateway_provider.py
+++ b/src/infrastructure/accuracy_testing/llm_gateway_provider.py
@@ -1,0 +1,188 @@
+"""Real IResponseProvider backed by an OpenAI-compatible LLM gateway.
+
+Card 2f9afe89: POST /accuracy/sessions needs actual AI responses to
+measure accuracy. This provider talks to the same gateway family as
+``qa_visual`` (OpenAI-compatible chat completions, Bearer auth, browser
+User-Agent against Cloudflare 1010) — pattern, not shared code.
+
+Design notes:
+
+- SYNC on purpose: ``IResponseProvider.get_response`` is a sync protocol
+  and the accuracy endpoints are sync handlers (FastAPI runs them in a
+  threadpool). Making the protocol async would ripple through the domain
+  layer for no benefit at this catalog size.
+- Injectable HTTP client: unit tests pass an ``httpx.Client`` with a
+  ``MockTransport`` so no test ever touches the network.
+- Fail-closed by omission: ``create_response_provider_from_env`` returns
+  ``None`` when no API key is configured, so the endpoint keeps its
+  explicit 503 "not configured" signal instead of half-working.
+- CWE-209 / S-3: upstream bodies are logged server-side only; the raised
+  error message carries the status/category, never the body.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+
+from src.domain.accuracy_testing.interfaces import IResponseProvider
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://opencode.ai/zen/go/v1/chat/completions"
+DEFAULT_MODEL = "deepseek-v4-flash-vision-exp"
+DEFAULT_TIMEOUT_S = 60.0
+DEFAULT_MAX_TOKENS = 1024
+
+# Browser UA required to avoid Cloudflare 1010 rejections (qa_visual C3).
+BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+)
+
+# Neutral persona: the model under test answers the benchmark question as
+# itself. The provider never receives ground truth (the session store only
+# forwards ``benchmark.question``), so no evaluation leakage is possible.
+SYSTEM_PROMPT = (
+    "You are a legal information assistant. Answer the user's question concisely and accurately."
+)
+
+
+class LLMGatewayProviderError(RuntimeError):
+    """Raised when the LLM gateway call fails or returns an unusable body.
+
+    The message is sanitized (status/category only) so it can safely cross
+    the API boundary; upstream bodies stay in server logs.
+    """
+
+
+class LLMGatewayResponseProvider(IResponseProvider):
+    """``IResponseProvider`` implementation calling an LLM gateway.
+
+    Args:
+        api_key: gateway credentials (env-only in production, never committed).
+        base_url: OpenAI-compatible chat completions endpoint.
+        model: default model id under test.
+        timeout_s: per-request timeout in seconds.
+        max_tokens: completion cap.
+        http_client: injectable ``httpx.Client`` (tests use ``MockTransport``);
+            when omitted, a client is created with ``timeout_s``.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = DEFAULT_BASE_URL,
+        model: str = DEFAULT_MODEL,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        self.api_key = api_key
+        self.base_url = base_url
+        self.model = model
+        self.timeout_s = timeout_s
+        self.max_tokens = max_tokens
+        self._owns_client = http_client is None
+        self._client = http_client or httpx.Client(timeout=timeout_s)
+
+    def get_response(self, prompt: str, model: str = "") -> str:
+        """Fetch an AI response for ``prompt`` (``model`` overrides the
+        configured default for this call)."""
+        if not self.api_key:
+            raise LLMGatewayProviderError(
+                "API key missing: set ACCURACY_PROVIDER_API_KEY in the environment"
+            )
+
+        payload = {
+            "model": model or self.model,
+            "messages": [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            "max_tokens": self.max_tokens,
+            "temperature": 0.1,
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": BROWSER_USER_AGENT,
+        }
+
+        try:
+            response = self._client.post(self.base_url, json=payload, headers=headers)
+        except httpx.TimeoutException as exc:
+            raise LLMGatewayProviderError(f"Gateway timeout: {type(exc).__name__}") from exc
+        except httpx.HTTPError as exc:
+            raise LLMGatewayProviderError("Gateway connection error") from exc
+
+        if response.status_code != 200:
+            # CWE-209 (S-3): upstream body stays in server logs only.
+            logger.error(
+                "Accuracy LLM gateway HTTP %s: %s",
+                response.status_code,
+                response.text[:200],
+            )
+            raise LLMGatewayProviderError(f"Gateway HTTP {response.status_code}")
+
+        try:
+            body = response.json()
+            content = body["choices"][0]["message"]["content"]
+        except (ValueError, KeyError, IndexError, TypeError) as exc:
+            raise LLMGatewayProviderError(
+                f"Malformed gateway response: {type(exc).__name__}"
+            ) from exc
+        if not isinstance(content, str):
+            # null/non-string content breaks the -> str contract; "" is the
+            # only acceptable empty answer (measurable by the evaluator).
+            raise LLMGatewayProviderError("Malformed gateway response: non-string content")
+
+        # An empty completion is a measurable bad answer, not a transport
+        # error: return it verbatim and let the evaluator score it.
+        return content
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name, "")
+    try:
+        return float(raw) if raw else default
+    except ValueError:
+        logger.warning("Invalid %s=%r; falling back to %s", name, raw, default)
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "")
+    try:
+        return int(raw) if raw else default
+    except ValueError:
+        logger.warning("Invalid %s=%r; falling back to %s", name, raw, default)
+        return default
+
+
+def create_response_provider_from_env() -> LLMGatewayResponseProvider | None:
+    """Build the provider from deploy env vars.
+
+    Returns ``None`` when no API key is configured (checked in order:
+    ``ACCURACY_PROVIDER_API_KEY``, then the repo-wide ``OPENCODE_GO_API_KEY``),
+    keeping POST /accuracy/sessions at its explicit 503 "not configured".
+    """
+    api_key = (
+        os.environ.get("ACCURACY_PROVIDER_API_KEY") or os.environ.get("OPENCODE_GO_API_KEY") or ""
+    ).strip()
+    if not api_key:
+        return None
+
+    return LLMGatewayResponseProvider(
+        api_key=api_key,
+        base_url=os.environ.get("ACCURACY_PROVIDER_BASE_URL", DEFAULT_BASE_URL),
+        model=os.environ.get("ACCURACY_PROVIDER_MODEL", DEFAULT_MODEL),
+        timeout_s=_env_float("ACCURACY_PROVIDER_TIMEOUT_S", DEFAULT_TIMEOUT_S),
+        max_tokens=_env_int("ACCURACY_PROVIDER_MAX_TOKENS", DEFAULT_MAX_TOKENS),
+    )

--- a/tests/unit/api/test_accuracy_endpoint_contracts.py
+++ b/tests/unit/api/test_accuracy_endpoint_contracts.py
@@ -255,6 +255,80 @@ class TestAC2CanaryAntiLeak:
         }
 
 
+# ------------------------------------------------------------------------
+# Response provider wiring (card 2f9afe89)
+# ------------------------------------------------------------------------
+
+
+class _FailingProvider:
+    """IResponseProvider whose gateway call fails (raises provider error)."""
+
+    def get_response(self, prompt: str, model: str = "") -> str:
+        from src.infrastructure.accuracy_testing.llm_gateway_provider import (
+            LLMGatewayProviderError,
+        )
+
+        raise LLMGatewayProviderError("Gateway HTTP 500")
+
+
+class TestProviderFailureMapping:
+    def test_provider_failure_maps_to_502(self):
+        client = _make_client(TENANT_A, provider=_FailingProvider())
+        resp = client.post("/accuracy/sessions", json={"ai_model": "test-model"})
+        assert resp.status_code == 502, resp.text
+
+    def test_provider_failure_detail_is_generic(self):
+        """CWE-209: the 502 detail must not echo upstream provider internals."""
+        client = _make_client(TENANT_A, provider=_FailingProvider())
+        resp = client.post("/accuracy/sessions", json={"ai_model": "test-model"})
+        assert resp.status_code == 502
+        assert "Gateway HTTP 500" not in resp.text
+
+
+class TestProviderEndpointIntegration:
+    """AC1 proof: POST /sessions returns 200 with a REAL provider wired
+    through DI (the provider's HTTP client is a MockTransport — no network)."""
+
+    def test_session_200_with_gateway_provider(self):
+        import httpx
+
+        from src.infrastructure.accuracy_testing.llm_gateway_provider import (
+            LLMGatewayResponseProvider,
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {
+                            "message": {
+                                "content": "MOCK-LLM-ANSWER liability depends on the defect."
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ]
+                },
+            )
+
+        provider = LLMGatewayResponseProvider(
+            api_key="integration-key",
+            http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+        )
+        client = _make_client(TENANT_A, provider=provider)
+
+        created = client.post("/accuracy/sessions", json={"ai_model": ""})
+        assert created.status_code == 200, created.text
+        body = created.json()
+
+        evaluations = body["evaluations"]
+        assert evaluations, "eval-set items must carry detailed evaluations"
+        for evaluation in evaluations:
+            assert "MOCK-LLM-ANSWER" in evaluation["ai_response"]
+
+        provider.close()
+
+
 def _deep_keys(obj) -> set:
     """Collect every dict key at any depth (canary: holdout_benchmarks)."""
     keys = set()

--- a/tests/unit/api/test_accuracy_endpoint_contracts.py
+++ b/tests/unit/api/test_accuracy_endpoint_contracts.py
@@ -264,9 +264,7 @@ class _FailingProvider:
     """IResponseProvider whose gateway call fails (raises provider error)."""
 
     def get_response(self, prompt: str, model: str = "") -> str:
-        from src.infrastructure.accuracy_testing.llm_gateway_provider import (
-            LLMGatewayProviderError,
-        )
+        from src.infrastructure.accuracy_testing.llm_gateway_provider import LLMGatewayProviderError
 
         raise LLMGatewayProviderError("Gateway HTTP 500")
 

--- a/tests/unit/infrastructure/test_llm_gateway_provider.py
+++ b/tests/unit/infrastructure/test_llm_gateway_provider.py
@@ -1,0 +1,273 @@
+"""Unit tests for the LLM gateway response provider (card 2f9afe89).
+
+All network interaction is simulated with ``httpx.MockTransport`` — the
+provider's HTTP client is injectable, so these tests never touch the
+network (same DI pattern as the qa_visual gateway client tests).
+"""
+
+import json
+
+import httpx
+import pytest
+
+from src.infrastructure.accuracy_testing.llm_gateway_provider import (
+    DEFAULT_BASE_URL,
+    DEFAULT_MODEL,
+    LLMGatewayProviderError,
+    LLMGatewayResponseProvider,
+    create_response_provider_from_env,
+)
+
+GATEWAY_ANSWER = "According to the ruling, liability depends on the defect and producer fault."
+
+
+def ok_response_body(content: str = GATEWAY_ANSWER, model: str = DEFAULT_MODEL) -> dict:
+    return {
+        "model": model,
+        "choices": [
+            {"message": {"content": content}, "finish_reason": "stop"},
+        ],
+        "usage": {"prompt_tokens": 100, "completion_tokens": 40},
+    }
+
+
+def make_provider(handler, **overrides) -> LLMGatewayResponseProvider:
+    defaults = {"api_key": "test-key"}
+    defaults.update(overrides)
+    transport = httpx.MockTransport(handler)
+    return LLMGatewayResponseProvider(http_client=httpx.Client(transport=transport), **defaults)
+
+
+class TestRequestContract:
+    def test_openai_chat_payload_shape(self):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["payload"] = json.loads(request.content)
+            return httpx.Response(200, json=ok_response_body())
+
+        provider = make_provider(handler)
+        provider.get_response("Who is liable for an AI defect?")
+
+        payload = captured["payload"]
+        assert payload["model"] == DEFAULT_MODEL
+        assert payload["max_tokens"] == 1024
+        assert payload["temperature"] == pytest.approx(0.1)
+        messages = payload["messages"]
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+        assert messages[1]["role"] == "user"
+        assert messages[1]["content"] == "Who is liable for an AI defect?"
+
+    def test_targets_configured_url(self):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            return httpx.Response(200, json=ok_response_body())
+
+        provider = make_provider(handler)
+        provider.get_response("q")
+
+        assert captured["url"] == DEFAULT_BASE_URL
+
+    def test_custom_base_url_used(self):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            return httpx.Response(200, json=ok_response_body())
+
+        provider = make_provider(handler, base_url="https://llm.internal/v1/chat/completions")
+        provider.get_response("q")
+
+        assert captured["url"] == "https://llm.internal/v1/chat/completions"
+
+    def test_bearer_auth_and_browser_user_agent(self):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["headers"] = request.headers
+            return httpx.Response(200, json=ok_response_body())
+
+        provider = make_provider(handler)
+        provider.get_response("q")
+
+        assert captured["headers"]["authorization"] == "Bearer test-key"
+        # Browser UA required by the gateway (same Cloudflare 1010 mitigation as qa_visual).
+        assert "Mozilla/5.0" in captured["headers"]["user-agent"]
+
+    def test_no_ground_truth_leakage_in_payload(self):
+        """The provider forwards the question only — it must never carry
+        benchmark ground truth (the caller controls what is sent, and the
+        session store only passes benchmark.question)."""
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["payload"] = json.loads(request.content)
+            return httpx.Response(200, json=ok_response_body())
+
+        provider = make_provider(handler)
+        provider.get_response("SYNTH-QUESTION-00 what is the answer?")
+
+        serialized = json.dumps(captured["payload"])
+        assert "SYNTH-TRUTH" not in serialized
+
+
+class TestGetResponse:
+    def test_returns_content_string(self):
+        provider = make_provider(
+            lambda request: httpx.Response(200, json=ok_response_body("plain answer"))
+        )
+        assert provider.get_response("q") == "plain answer"
+
+    def test_per_call_model_override(self):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["payload"] = json.loads(request.content)
+            return httpx.Response(200, json=ok_response_body())
+
+        provider = make_provider(handler)
+        provider.get_response("q", model="model-under-test-x")
+
+        assert captured["payload"]["model"] == "model-under-test-x"
+
+    def test_empty_content_is_returned_verbatim(self):
+        """An empty completion is a measurable bad answer, not a transport
+        error: return it and let the evaluator score it."""
+
+        provider = make_provider(lambda request: httpx.Response(200, json=ok_response_body("")))
+        assert provider.get_response("q") == ""
+
+
+class TestErrors:
+    def test_missing_api_key_raises(self):
+        provider = LLMGatewayResponseProvider(api_key="")
+        with pytest.raises(LLMGatewayProviderError, match="API key"):
+            provider.get_response("q")
+        provider.close()
+
+    def test_http_error_raises_sanitized(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(403, text="upstream secret detail")
+
+        provider = make_provider(handler)
+        with pytest.raises(LLMGatewayProviderError, match="403") as exc_info:
+            provider.get_response("q")
+        assert "upstream secret detail" not in str(exc_info.value)
+
+    def test_http_error_body_logged_not_raised(self, caplog):
+        """CWE-209: upstream body goes to server logs only."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="internal stack trace detail")
+
+        provider = make_provider(handler)
+        with caplog.at_level("ERROR"):
+            with pytest.raises(LLMGatewayProviderError):
+                provider.get_response("q")
+
+        assert any("internal stack trace detail" in r.message for r in caplog.records)
+
+    def test_timeout_raises(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectTimeout("timed out")
+
+        provider = make_provider(handler)
+        with pytest.raises(LLMGatewayProviderError, match="[Tt]imeout"):
+            provider.get_response("q")
+
+    def test_connect_error_raises(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused")
+
+        provider = make_provider(handler)
+        with pytest.raises(LLMGatewayProviderError, match="connection"):
+            provider.get_response("q")
+
+    def test_malformed_json_raises(self):
+        provider = make_provider(lambda request: httpx.Response(200, text="not-json{"))
+        with pytest.raises(LLMGatewayProviderError, match="[Mm]alformed"):
+            provider.get_response("q")
+
+    def test_unexpected_shape_raises(self):
+        provider = make_provider(lambda request: httpx.Response(200, json={"unexpected": "shape"}))
+        with pytest.raises(LLMGatewayProviderError, match="[Mm]alformed"):
+            provider.get_response("q")
+
+    def test_empty_choices_raises(self):
+        provider = make_provider(lambda request: httpx.Response(200, json={"choices": []}))
+        with pytest.raises(LLMGatewayProviderError, match="[Mm]alformed"):
+            provider.get_response("q")
+
+    def test_null_content_raises(self):
+        """A null content breaks the -> str contract: malformed, not a
+        measurable empty answer."""
+        provider = make_provider(
+            lambda request: httpx.Response(200, json={"choices": [{"message": {"content": None}}]})
+        )
+        with pytest.raises(LLMGatewayProviderError, match="[Mm]alformed"):
+            provider.get_response("q")
+
+
+class TestFactory:
+    def test_no_key_returns_none(self, monkeypatch):
+        monkeypatch.delenv("ACCURACY_PROVIDER_API_KEY", raising=False)
+        monkeypatch.delenv("OPENCODE_GO_API_KEY", raising=False)
+        assert create_response_provider_from_env() is None
+
+    def test_blank_key_returns_none(self, monkeypatch):
+        monkeypatch.setenv("ACCURACY_PROVIDER_API_KEY", "   ")
+        monkeypatch.delenv("OPENCODE_GO_API_KEY", raising=False)
+        assert create_response_provider_from_env() is None
+
+    def test_provider_key_builds_provider(self, monkeypatch):
+        monkeypatch.setenv("ACCURACY_PROVIDER_API_KEY", "key-1")
+        monkeypatch.delenv("OPENCODE_GO_API_KEY", raising=False)
+        provider = create_response_provider_from_env()
+        assert isinstance(provider, LLMGatewayResponseProvider)
+        assert provider.api_key == "key-1"
+        provider.close()
+
+    def test_fallback_to_opencode_go_key(self, monkeypatch):
+        monkeypatch.delenv("ACCURACY_PROVIDER_API_KEY", raising=False)
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "shared-key")
+        provider = create_response_provider_from_env()
+        assert provider is not None
+        assert provider.api_key == "shared-key"
+        provider.close()
+
+    def test_provider_key_takes_precedence_over_fallback(self, monkeypatch):
+        monkeypatch.setenv("ACCURACY_PROVIDER_API_KEY", "explicit")
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "fallback")
+        provider = create_response_provider_from_env()
+        assert provider.api_key == "explicit"
+        provider.close()
+
+    def test_env_overrides_applied(self, monkeypatch):
+        monkeypatch.setenv("ACCURACY_PROVIDER_API_KEY", "key-1")
+        monkeypatch.setenv("ACCURACY_PROVIDER_BASE_URL", "https://custom.example/v1/chat")
+        monkeypatch.setenv("ACCURACY_PROVIDER_MODEL", "custom-model")
+        monkeypatch.setenv("ACCURACY_PROVIDER_TIMEOUT_S", "12.5")
+        monkeypatch.setenv("ACCURACY_PROVIDER_MAX_TOKENS", "512")
+        provider = create_response_provider_from_env()
+        assert provider.base_url == "https://custom.example/v1/chat"
+        assert provider.model == "custom-model"
+        assert provider.timeout_s == 12.5
+        assert provider.max_tokens == 512
+        provider.close()
+
+    def test_invalid_timeout_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("ACCURACY_PROVIDER_API_KEY", "key-1")
+        monkeypatch.setenv("ACCURACY_PROVIDER_TIMEOUT_S", "not-a-number")
+        provider = create_response_provider_from_env()
+        assert provider.timeout_s == 60.0
+        provider.close()
+
+    def test_invalid_max_tokens_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("ACCURACY_PROVIDER_API_KEY", "key-1")
+        monkeypatch.setenv("ACCURACY_PROVIDER_MAX_TOKENS", "oops")
+        provider = create_response_provider_from_env()
+        assert provider.max_tokens == 1024
+        provider.close()


### PR DESCRIPTION
## Card 2f9afe89 — response provider real para POST /accuracy/sessions

Elimina el 503: `POST /accuracy/sessions` ahora es funcional con un provider LLM real (gateway OpenAI-compatible), configurable por env vars y sin romper el patrón DI del módulo.

### Approach (3 evaluados, 1 seleccionado)

- **A. Sync LLM gateway provider + env factory** — SELECCIONADO: implementa el Protocol `IResponseProvider` existente (sync), cliente httpx inyectable, patrón de gateway de qa_visual sin tocar qa_visual.
- B. Provider determinista — rechazado: no mide un sistema de IA real.
- C. Refactor async del Protocol — rechazado: ripple por dominio/tests sin beneficio al tamaño del catálogo (deferred).

### Acceptance criteria

| AC | Estado | Prueba |
|---|---|---|
| 1. POST /accuracy/sessions responde 200 con provider (no 503) | OK | `TestProviderEndpointIntegration::test_session_200_with_gateway_provider` (provider real + MockTransport vía DI) + wiring test del dashboard |
| 2. Provider inyectable, tests unitarios sin red | OK | `tests/unit/infrastructure/test_llm_gateway_provider.py` (22 tests, httpx.MockTransport, cero red) |
| 3. E2E básico | Handoff | Endpoint funcional + receta curl en docs para qa-tester |
| 4. Docs | OK | `docs/accuracy-testing.md` sección provider + env table + curl; CHANGELOG; design/plan en docs/specs + docs/plans |

### Seguridad

- CWE-209: errores del gateway saneados (status/categoría); body upstream solo a logs del servidor; 502 con detail genérico.
- Sin key configurada → provider `None` → el 503 explícito se mantiene (fail-closed por omisión).
- El provider solo recibe `benchmark.question` (nunca ground truth) — test anti-leak incluido.
- Forbidden zones intactos: qa_visual y dashboard middleware/rate_limit sin tocar.

### Deploy config

```bash
ACCURACY_TESTING_ENABLED=1
ACCURACY_SPLIT_SECRET=<secreto>
ACCURACY_PROVIDER_API_KEY=<key>   # fallback: OPENCODE_GO_API_KEY
# opcionales: ACCURACY_PROVIDER_BASE_URL / _MODEL / _TIMEOUT_S / _MAX_TOKENS
```

### Tests

- 43 pasados (módulo accuracy: provider + contracts + vendor parity), 8 domain accuracy, 6 dashboard wiring.
- Coverage del módulo nuevo (`llm_gateway_provider.py`): **100%** (66/66 stmts).
- Vendored copy sincronizado (vendor-parity test verde).