### PR TITLE
fix(monitoring): min-volume guards for cache hit-ratio alerts (card 78489ff6)

### DIFF
--- a/dashboard/monitoring/prometheus/alerts/qa-framework-alerts.yml
+++ b/dashboard/monitoring/prometheus/alerts/qa-framework-alerts.yml
@@ -89,6 +89,8 @@ groups:
             / 
             (pg_stat_database_blks_hit + pg_stat_database_blks_read)
           ) < 0.95
+          and on(instance,job)
+          (pg_stat_database_blks_hit + pg_stat_database_blks_read) > 10000
         for: 10m
         labels:
           severity: warning
@@ -127,6 +129,8 @@ groups:
             / 
             (redis_keyspace_hits_total + redis_keyspace_misses_total)
           ) < 0.8
+          and on(instance,job)
+          (redis_keyspace_hits_total + redis_keyspace_misses_total) > 1000
         for: 10m
         labels:
           severity: warning


### PR DESCRIPTION
## Qué
Guards de volumen mínimo para las 2 alertas de cache hit-ratio (falso positivo cold-cache):

- **RedisCacheHitRatioLow**: `and on(instance,job) (redis_keyspace_hits_total + redis_keyspace_misses_total) > 1000`
- **LowCacheHitRatio** (PostgreSQL): `and on(instance,job) (pg_stat_database_blks_hit + pg_stat_database_blks_read) > 10000`

## Por qué
La alerta Redis disparó 03:29 (y de nuevo hoy 10:43) tras recrear redis: cache fría con 14 ops totales (hits=8/misses=6, dbsize=0) → ratio 57% < 80% → firing spam a Telegram. Un ratio sin volumen mínimo no es señal. Mismo patrón cold-start aplica a PG tras restart de DB.

## Validación
- `promtool check rules` (container prom/prometheus:v3.14.0): SUCCESS, 19 rules — antes y después del cambio.

## Workboard
Card **78489ff6-73e2-4559-8525-1da86b4367f2** (proof gate reference). Mitigación temporal previa: silence amtool 24h (ya expirado).