### PR TITLE
fix(dashboard): fastapi 0.122.0 (starlette>=0.42) auth 401 + purge Railway Redis credential

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -175,12 +175,22 @@ jobs:
             --no-cov \
             --junitxml=junit-middleware.xml
 
+      - name: Run dashboard wiring tests
+        if: steps.changed-files.outputs.run_middleware_tests == 'true'
+        run: |
+          cd dashboard/backend
+          python -m pytest tests/test_accuracy_wiring.py tests/test_qa_visual_wiring.py tests/test_qa_visual_feature_flag.py -v \
+            --no-cov \
+            --junitxml=junit-wiring.xml
+
       - name: Upload middleware test results
         if: steps.changed-files.outputs.run_middleware_tests == 'true' && always()
         uses: actions/upload-artifact@v4 # v4.6.2
         with:
           name: middleware-test-results
-          path: dashboard/backend/junit-middleware.xml
+          path: |
+            dashboard/backend/junit-middleware.xml
+            dashboard/backend/junit-wiring.xml
 
   # PR size check
   pr-size-check:

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to the QA-Framework Dashboard project will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+#### Secrets Remediation
+- **Removed hardcoded Railway Redis credentials from the repository**: the
+  production credential was embedded in test fixtures and docs
+  - `backend/tests/conftest.py`: REDIS_URL fallback now uses local Redis
+    (`redis://127.0.0.1:6379/0`); redis stays mocked in tests, so no real
+    connection is attempted
+  - `backend/tests/infrastructure/test_test_cache.py` and
+    `test_test_cache_backup.py`: fixture default switched to local Redis
+  - `backend/TEST_FIX_PROMPT.md`: example REDIS_URL switched to local Redis
+  - NOTE: the credential remains in git history prior to this change and must
+    be rotated on the Railway side
+
+### Fixed
+#### Dependencies
+- **Bumped FastAPI 0.115.4 -> 0.122.0 with Starlette >= 0.42**: FastAPI <= 0.121
+  returns 403 Forbidden (instead of 401 Unauthorized) when `HTTPBearer` finds
+  no credentials; 0.122.0 introduced `HTTPBase.make_not_authenticated_error()`
+  answering 401 with `WWW-Authenticate`
+  - Unblocked `test_accuracy_mounted_rejects_unauthenticated` and
+    `test_accuracy_mount_with_provider_env_assembles` (wiring suite back to 6/6)
+
+### Changed
+#### CI
+- **Dashboard wiring suites now run in PR checks**: the
+  `dashboard-middleware-tests` job (required check) additionally runs
+  `test_accuracy_wiring.py`, `test_qa_visual_wiring.py` and
+  `test_qa_visual_feature_flag.py` and uploads their JUnit report
+
 ## [0.3.0] - 2026-02-13
 
 ### Fixed

--- a/dashboard/backend/TEST_FIX_PROMPT.md
+++ b/dashboard/backend/TEST_FIX_PROMPT.md
@@ -8,9 +8,9 @@ You're working on QA-FRAMEWORK backend. We fixed Redis connection to use Railway
 - **698 passing (92%)** - These use real Redis correctly
 - **59 failing (8%)** - These expect mocks
 
-## Railway Redis (ALREADY WORKING)
+## Local Redis
 ```
-REDIS_URL=redis://default:ygZpOipKeuDfOvlxRPrRNGxxeJKsPrPD@centerbeam.proxy.rlwy.net:20994
+REDIS_URL=redis://127.0.0.1:6379/0
 ```
 
 Configured in:

--- a/dashboard/backend/requirements.txt
+++ b/dashboard/backend/requirements.txt
@@ -1,4 +1,5 @@
-fastapi==0.115.4
+fastapi==0.122.0
+starlette>=0.42
 uvicorn[standard]==0.32.0
 sqlalchemy==2.0.36
 asyncpg==0.30.0

--- a/dashboard/backend/tests/conftest.py
+++ b/dashboard/backend/tests/conftest.py
@@ -3,11 +3,13 @@ Pytest configuration and fixtures
 
 This file configures pytest to work with the backend module structure.
 """
-import sys
+
 import os
+import sys
 from pathlib import Path
-from dotenv import load_dotenv
 from unittest.mock import MagicMock
+
+from dotenv import load_dotenv
 
 # Mock Redis to avoid connection errors during import
 _mock_redis = MagicMock()
@@ -37,15 +39,14 @@ else:
         load_dotenv(root_env)
         print(f"Loaded environment from: {root_env}")
 
-# Set Railway Redis URL if not already set (fallback for CI/testing)
+# Local Redis fallback for CI/testing (no credentials; redis is mocked in tests)
 if not os.getenv("REDIS_URL"):
-    railway_redis = "redis://default:ygZpOipKeuDfOvlxRPrRNGxxeJKsPrPD@centerbeam.proxy.rlwy.net:20994"
-    os.environ["REDIS_URL"] = railway_redis
-    print("Using Railway Redis URL for testing")
+    os.environ["REDIS_URL"] = "redis://127.0.0.1:6379/0"
 
 print(f"Backend directory: {backend_dir}")
 print(f"Python path: {sys.path[:3]}")  # Show first 3 paths
 
 # Configure logging before any tests run
 from core.logging_config import configure_logging
+
 configure_logging(log_level="WARNING", environment="test")

--- a/dashboard/backend/tests/infrastructure/test_test_cache.py
+++ b/dashboard/backend/tests/infrastructure/test_test_cache.py
@@ -23,8 +23,8 @@ class TestTestCache:
 
     @pytest.fixture
     def redis_url(self):
-        """Get Redis URL from environment or use Railway."""
-        return os.getenv("REDIS_URL", "redis://default:ygZpOipKeuDfOvlxRPrRNGxxeJKsPrPD@centerbeam.proxy.rlwy.net:20994")
+        """Get Redis URL from environment or use local Redis."""
+        return os.getenv("REDIS_URL", "redis://127.0.0.1:6379/0")
 
     @pytest.fixture
     def test_cache(self, redis_url):

--- a/dashboard/backend/tests/infrastructure/test_test_cache_backup.py
+++ b/dashboard/backend/tests/infrastructure/test_test_cache_backup.py
@@ -23,8 +23,8 @@ class TestTestCache:
 
     @pytest.fixture
     def redis_url(self):
-        """Get Redis URL from environment or use Railway."""
-        return os.getenv("REDIS_URL", "redis://default:ygZpOipKeuDfOvlxRPrRNGxxeJKsPrPD@centerbeam.proxy.rlwy.net:20994")
+        """Get Redis URL from environment or use local Redis."""
+        return os.getenv("REDIS_URL", "redis://127.0.0.1:6379/0")
 
     @pytest.fixture
     def mock_redis(self):


### PR DESCRIPTION
## What was done
- **Deps bump**: `fastapi==0.115.4` -> `fastapi==0.122.0` + explicit `starlette>=0.42` in `dashboard/backend/requirements.txt`. Root cause refined during TDD: the 403-vs-401 behaviour lives in **FastAPI** (`HTTPBase.__call__` in `fastapi/security/http.py`), not in starlette itself — FastAPI <= 0.121 raises `HTTP_403_FORBIDDEN` for missing bearer credentials; 0.122.0 introduced `make_not_authenticated_error()` answering **401** with `WWW-Authenticate`. The `starlette>=0.42` floor required by the card is honored and satisfied (resolved: starlette 0.42.0, `pip check` clean, pydantic 2.9.2 unchanged).
- **Secret purge**: removed the hardcoded Railway Redis production credential (4 occurrences) and replaced every fallback with local `redis://127.0.0.1:6379/0`. Redis remains mocked in `tests/conftest.py`, so no real connection is attempted.
- **CI**: the required job `dashboard-middleware-tests` (check name "Dashboard Backend Middleware Tests") now also runs the dashboard wiring suites and uploads their JUnit report.
- **CHANGELOG**: `dashboard/CHANGELOG.md` [Unreleased] entry added.

## Where artifacts are
- `dashboard/backend/requirements.txt` — fastapi/starlette pins
- `dashboard/backend/tests/conftest.py` — REDIS_URL fallback de-credentialed (+ isort import order)
- `dashboard/backend/tests/infrastructure/test_test_cache.py`, `test_test_cache_backup.py` — fixture default de-credentialed
- `dashboard/backend/TEST_FIX_PROMPT.md` — example REDIS_URL de-credentialed
- `.github/workflows/pr-checks.yml` — wiring test step + artifact
- `dashboard/CHANGELOG.md`

## How to verify
```bash
python3 -m venv /tmp/v && /tmp/v/bin/pip install -r dashboard/backend/requirements.txt
cd dashboard/backend && /tmp/v/bin/python -m pytest tests/test_accuracy_wiring.py --no-cov -v        # 6 passed
/tmp/v/bin/python -m pytest tests/middleware tests/test_qa_visual_wiring.py tests/test_qa_visual_feature_flag.py tests/test_accuracy_wiring.py --no-cov -q  # 61 passed
cd ../.. && python3 -m pytest tests -k accuracy -q                                                  # 135 passed, 4 skipped
python3 -m pytest tests/unit -q                                                                     # 790 passed, 10 skipped
grep -rn "rlwy.net" . --exclude-dir=.git                                                          # no matches
```
TDD evidence: on the pre-fix pins (fastapi 0.115.4 / starlette 0.41.3) the suite reproduced the exact RED from the card: `test_accuracy_mounted_rejects_unauthenticated` and `test_accuracy_mount_with_provider_env_assembles` failing with `assert 403 == 401` (2 failed, 4 passed).

## Known issues
- **The Railway credential is still in git history** (commits at and before 5d9fa41) and appears in this PR's diff only as removed lines. It MUST be rotated/revoked on the Railway side — removing it from HEAD does not invalidate the leak.
- `tests/infrastructure/test_test_cache*.py` carry pre-existing ruff/isort findings (F401/I001) that predate this PR; CI lint jobs only cover root `src`/`tests`, so they are untouched here to keep the diff surgical.
- The card's "162 tests accuracy scope" count could not be reproduced exactly (scope accuracy resolves to 135-139 tests depending on selection); all accuracy-scoped tests pass.

## What's next
- Rotate the Railway Redis credential (owner action, outside repo).
- CI on this PR must pass the 6 required checks (PR Validation, Code Quality Checks, E2E Tests, OWASP Security Gate, Trivy Security Gate, Dashboard Backend Middleware Tests) — isort/ruff run locally on touched files: clean.
- Do NOT merge from this agent; pipeline order: security-auditor -> QA -> review.