### PR TITLE
fix(security): PR #134 advisories — blank-owner guard, 403/401 pins, is_admin standalone, 404 contract (card 52585523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   username. Applied to both module copies (root `src/` and the vendored
   `dashboard/backend/src/`).
 
+- **PR #134 security-review advisories (card 52585523)**: four follow-ups
+  on the QA Visual auth path. (1) owner-blank storage guard:
+  `QAVisualReportStore.get_report` now fail-closes on ANY blank owner
+  (`None`, `""`, whitespace) — previously `owner=""` bypassed the guard
+  and matched reports stamped with a blank owner, so a blank-scope caller
+  could read blank-stamped reports; admins keep their escape hatch.
+  (2) fastapi>=0.122 HTTPBearer semantics: verified empirically that
+  unauthenticated requests answer 401 (403 before 0.122); all exact `== 403`
+  pins in the repo are authorization-level (authenticated non-owner /
+  suspended tenant) and proven version-stable (root suite green under both
+  0.115.4 and 0.136.3); the dashboard stack (pinned `fastapi==0.122.0`)
+  gains an exact 401 pin for missing credentials. (3) standalone
+  characterization test: `is_admin=True` alone authorizes cross-owner
+  reads, independent of fixtures or test order. (4) 403/404 enumeration
+  contract: a nonexistent report id answers 404 for every authenticated
+  principal (owner, non-owner, admin) — 403 remains reserved for reports
+  that exist (accepted adv-1 tradeoff) — now covered at module and
+  real-app level. Vendored copy synced (vendor-parity test).
+
 ### Added
 
 - **Accuracy response provider (card 2f9afe89)**: real

--- a/dashboard/backend/src/infrastructure/qa_visual/storage.py
+++ b/dashboard/backend/src/infrastructure/qa_visual/storage.py
@@ -96,16 +96,19 @@ class QAVisualReportStore:
 
         Fail-closed: callers must state who is asking — an explicit
         ``owner`` to scope the read, or ``is_admin=True`` to lift the
-        scoping. A call with neither is a programming error, so a new
-        caller can never silently read every tenant's reports.
+        scoping. A call with neither, or with a blank owner (``None``,
+        ``""``, whitespace), is a programming error, so a new caller can
+        never silently read every tenant's reports — nor can a blank
+        scope match reports stamped with a blank owner.
 
         Returns ``None`` when no report with that id exists; raises
         ``ReportAccessDenied`` when it exists but belongs to another
         owner (legacy unowned reports are admin-only, as everywhere).
         """
-        if owner is None and not is_admin:
+        # PR #134 advisory item 1: blank owners are not scopes (fail-closed).
+        if not (owner or "").strip() and not is_admin:
             raise ValueError(
-                "get_report() requires an explicit owner or is_admin=True (fail-closed)"
+                "get_report() requires a non-empty owner or is_admin=True (fail-closed)"
             )
         for path in self._dir.glob("*.json") if self._dir.exists() else []:
             report = self._read_report(path)

--- a/dashboard/backend/tests/test_qa_visual_owner_scoping.py
+++ b/dashboard/backend/tests/test_qa_visual_owner_scoping.py
@@ -202,6 +202,13 @@ class TestRealAppOwnerScoping:
         response = client.get("/api/v1/qa-visual/reports/missing", headers=auth_headers["alice"])
         assert response.status_code == 404
 
+    def test_unknown_report_404_for_non_owner(self, client, auth_headers):
+        """PR #134 advisory item 4: nonexistent id → 404 for an authenticated
+        non-owner (valid tenant), never 403 — 403 only means "exists but
+        forbidden", so a missing report must never answer 403."""
+        response = client.get("/api/v1/qa-visual/reports/missing", headers=auth_headers["bob"])
+        assert response.status_code == 404
+
     def test_reports_listing_scoped_to_owner(self, client, auth_headers):
         body = client.get("/api/v1/qa-visual/reports", headers=auth_headers["alice"]).json()
         assert sorted(r["report_id"] for r in body) == ["rep-alice-1", "rep-alice-2"]

--- a/dashboard/backend/tests/test_qa_visual_wiring.py
+++ b/dashboard/backend/tests/test_qa_visual_wiring.py
@@ -66,6 +66,20 @@ class TestMainAppAuthEnforcement:
         for path in GET_PATHS:
             assert main_client.get(path).status_code in (401, 403), path
 
+    def test_no_credentials_exact_401_under_fastapi_ge_0122(self, main_client):
+        """PR #134 advisory item 2: exact unauthenticated-status pin.
+
+        fastapi>=0.122 changed HTTPBearer (auto_error=True) to answer 401
+        "Not authenticated" for missing credentials — 403 before 0.122.
+        backend requirements pin fastapi==0.122.0, so the exact pin on this
+        stack is 401; if this fails after a fastapi bump/downgrade, the
+        unauthenticated-status semantics regressed and dependent 403 pins
+        must be re-audited.
+        """
+        for path in GET_PATHS:
+            response = main_client.get(path)
+            assert response.status_code == 401, (path, response.status_code)
+
     def test_no_credentials_rejected_analyze(self, main_client):
         response = main_client.post(
             "/api/v1/qa-visual/analyze",

--- a/src/infrastructure/qa_visual/storage.py
+++ b/src/infrastructure/qa_visual/storage.py
@@ -96,16 +96,19 @@ class QAVisualReportStore:
 
         Fail-closed: callers must state who is asking — an explicit
         ``owner`` to scope the read, or ``is_admin=True`` to lift the
-        scoping. A call with neither is a programming error, so a new
-        caller can never silently read every tenant's reports.
+        scoping. A call with neither, or with a blank owner (``None``,
+        ``""``, whitespace), is a programming error, so a new caller can
+        never silently read every tenant's reports — nor can a blank
+        scope match reports stamped with a blank owner.
 
         Returns ``None`` when no report with that id exists; raises
         ``ReportAccessDenied`` when it exists but belongs to another
         owner (legacy unowned reports are admin-only, as everywhere).
         """
-        if owner is None and not is_admin:
+        # PR #134 advisory item 1: blank owners are not scopes (fail-closed).
+        if not (owner or "").strip() and not is_admin:
             raise ValueError(
-                "get_report() requires an explicit owner or is_admin=True (fail-closed)"
+                "get_report() requires a non-empty owner or is_admin=True (fail-closed)"
             )
         for path in self._dir.glob("*.json") if self._dir.exists() else []:
             report = self._read_report(path)

--- a/tests/unit/infrastructure/test_qa_visual_owner_scoping.py
+++ b/tests/unit/infrastructure/test_qa_visual_owner_scoping.py
@@ -242,6 +242,18 @@ class TestEndpointOwnerEnforcement:
     def test_missing_report_404_for_owner(self, endpoint):
         assert endpoint.client(ALICE).get("/api/v1/qa-visual/reports/missing").status_code == 404
 
+    def test_missing_report_404_for_non_owner(self, endpoint):
+        """PR #134 advisory item 4: 403 is reserved for reports that exist.
+
+        A nonexistent id answers 404 even for an authenticated non-owner,
+        so the error code never signals the existence of a missing report
+        (403 = "exists but forbidden" is the accepted adv-1 tradeoff).
+        """
+        assert endpoint.client(BOB).get("/api/v1/qa-visual/reports/missing").status_code == 404
+
+    def test_missing_report_404_for_admin(self, endpoint):
+        assert endpoint.client(ADMIN).get("/api/v1/qa-visual/reports/missing").status_code == 404
+
     def test_legacy_report_403_for_regular_user(self, endpoint):
         assert endpoint.client(ALICE).get("/api/v1/qa-visual/reports/rep-legacy").status_code == 403
 

--- a/tests/unit/infrastructure/test_qa_visual_storage.py
+++ b/tests/unit/infrastructure/test_qa_visual_storage.py
@@ -9,7 +9,13 @@ from src.infrastructure.qa_visual.models import AnalyzeResponse, QAAnalysis
 from src.infrastructure.qa_visual.storage import QAVisualReportStore
 
 
-def make_response(report_id="r1", target="amc", score=95, passed=True) -> AnalyzeResponse:
+def make_response(
+    report_id="r1",
+    target="amc",
+    score=95,
+    passed=True,
+    owner=None,
+) -> AnalyzeResponse:
     return AnalyzeResponse(
         report_id=report_id,
         target=target,
@@ -21,6 +27,7 @@ def make_response(report_id="r1", target="amc", score=95, passed=True) -> Analyz
         latency_s=4.37,
         model="deepseek-v4-flash-vision-exp",
         regression_detected=False,
+        owner=owner,
     )
 
 
@@ -88,6 +95,53 @@ class TestListAndGet:
 
     def test_get_missing_returns_none(self, store):
         assert store.get_report("nope", is_admin=True) is None
+
+
+class TestOwnerGuardFailClosed:
+    """PR #134 advisory item 1: a blank owner must never act as a report scope.
+
+    ``QAVisualPrincipal`` rejects blank owners, but ``AnalyzeResponse.owner``
+    has no such validator — reports stamped ``owner=""`` can reach disk via
+    direct ``store.save()`` or a buggy producer. The storage guard must
+    therefore fail closed on ANY blank owner (None, "", whitespace) instead
+    of matching blank-scope reads against blank-stamped reports.
+    """
+
+    def test_get_report_with_none_owner_fails_closed(self, store):
+        store.save(make_response(report_id="r-none", target="amc"))
+        with pytest.raises(ValueError):
+            store.get_report("r-none", owner=None, is_admin=False)
+
+    def test_get_report_with_empty_owner_string_fails_closed(self, store):
+        store.save(make_response(report_id="r-blank", target="amc", owner=""))
+        with pytest.raises(ValueError):
+            store.get_report("r-blank", owner="")
+
+    def test_get_report_with_whitespace_owner_fails_closed(self, store):
+        store.save(make_response(report_id="r-space", target="amc", owner="  "))
+        with pytest.raises(ValueError):
+            store.get_report("r-space", owner="  ")
+
+    def test_admin_still_reads_blank_owner_report(self, store):
+        """Admins keep their documented escape hatch for malformed reports."""
+        store.save(make_response(report_id="r-blank", target="amc", owner=""))
+        report = store.get_report("r-blank", is_admin=True)
+        assert report is not None
+        assert report["report_id"] == "r-blank"
+
+    def test_is_admin_true_alone_authorizes_cross_owner_read(self, tmp_path):
+        """PR #134 advisory item 3: is_admin=True by itself lifts owner scoping.
+
+        Standalone by design: own store, own seed, no shared fixtures — the
+        admin authorization contract must not depend on test order or on
+        principals minted by other tests.
+        """
+        store = QAVisualReportStore(reports_dir=str(tmp_path / "qa-visual"))
+        store.save(make_response(report_id="r-alice", target="amc", owner="alice"))
+        report = store.get_report("r-alice", is_admin=True)
+        assert report is not None
+        assert report["report_id"] == "r-alice"
+        assert report["owner"] == "alice"
 
 
 class TestBaseline:


### PR DESCRIPTION
## Card 52585523 [P3] — QA-FW: PR #134 advisories (4 items del security review de auth hardening)

Base: `origin/main` 7f81231 (post-#136). Branch: `fix/134-advisories`.

### What was done

1. **Owner-blank storage guard (adv-1 follow-up)**: `QAVisualReportStore.get_report` fail-closed ahora rechaza CUALQUIER owner en blanco (`None`, `""`, whitespace) — antes `owner=""` bypassaba el guard (`owner is None`) y hacía match con reports sellados `owner=""` (`AnalyzeResponse.owner` no tiene validador, pueden llegar a disco). Admin conserva su escape hatch. Fix de 1 línea + 5 tests (TDD: 2 RED reproducidos antes del fix — empty y whitespace devolvían el report en vez de raisear).
2. **Pins 403 exactos (fastapi>=0.122)**: verificado EMPÍRICAMENTE que HTTPBearer(auto_error=True) responde 401 (antes 403) para credenciales ausentes bajo >=0.122 (probe: 0.115.4→403, 0.136.3→401). Clasificación de los 4 pins exactos `== 403` del repo: todos son authorization-level (non-owner autenticado via ReportAccessDenied, suspended tenant via middleware) → **ningún assert requería cambio**; suite raíz verde bajo 0.115.4 Y 0.136.3 lo prueba. Añadido pin exacto 401 en el stack que fija `fastapi==0.122.0` (dashboard wiring) para detectar regresión semántica en bumps.
3. **is_admin explícito standalone**: test de caracterización self-contained (store propio, seed propio, sin fixtures compartidas) que documenta que `is_admin=True` por sí solo autoriza lectura cross-owner.
4. **eval 403/404**: evaluación — un id inexistente devuelve 404 para cualquier principal autenticado (owner/non-owner/admin); el 403 queda reservado para reports existentes (tradeoff adv-1 aceptado y documentado). Cubierto con 3 tests nuevos (2 módulo + 1 real-app con tenant válido non-owner → 404 exacto).

### Where artifacts are

- `src/infrastructure/qa_visual/storage.py` — guard (línea ~109) + docstring
- `dashboard/backend/src/infrastructure/qa_visual/storage.py` — copia vendored sincronizada (vendor-parity test)
- `tests/unit/infrastructure/test_qa_visual_storage.py` — clase `TestOwnerGuardFailClosed` (6 tests)
- `tests/unit/infrastructure/test_qa_visual_owner_scoping.py` — 2 tests 404 non-owner/admin
- `dashboard/backend/tests/test_qa_visual_owner_scoping.py` — 1 test 404 non-owner (real app)
- `dashboard/backend/tests/test_qa_visual_wiring.py` — pin exacto 401 bajo fastapi>=0.122
- `CHANGELOG.md` — entrada Security bajo Unreleased

### How to verify

```bash
# Suite raíz (CI usa poetry, fastapi 0.115.4)
/tmp/pr135-venv/bin/python -m pytest tests/unit -q        # 797 passed, 10 skipped
# Estabilidad de versión (fastapi 0.136.3 >= 0.122)
python3 -m pytest tests/unit/infrastructure/test_qa_visual_storage.py tests/unit/infrastructure/test_qa_visual_owner_scoping.py tests/unit/infrastructure/test_qa_visual_endpoint.py tests/unit/infrastructure/test_qa_visual_storage_fail_closed.py -q   # 88 passed
# Dashboard real-app (fastapi 0.122.0, desde dashboard/backend)
/tmp/opencode/qa-fw-venv/bin/python -m pytest tests/test_qa_visual_owner_scoping.py tests/test_qa_visual_wiring.py tests/test_qa_visual_feature_flag.py -q   # 35 passed
# Gates obligatorios del CI
ruff check src tests          # All checks passed
isort --check-only src tests  # OK
black --check --diff --line-length 100 src/infrastructure/qa_visual/storage.py tests/unit/infrastructure/test_qa_visual_storage.py tests/unit/infrastructure/test_qa_visual_owner_scoping.py  # unchanged
```

### Known issues

- `python-multipart` instalado en `/tmp/pr135-venv` (gap de entorno local, no de código; CI lo trae via poetry).
- mypy no disponible localmente; el cambio es tipográficamente trivial (`str | None` → `(owner or "").strip()` → `bool`), sin cambios de firma. CI (`mypy src --strict`) confirmará.
- Preexistente (fuera de scope): 3 × ruff UP017 (`timezone.utc` → `UTC`) en `dashboard/backend/tests/test_qa_visual_owner_scoping.py` líneas 42/48/56, código anterior a este PR y fuera del gate CI (`ruff check src tests` = raíz).
- Diagnósticos LSP preexistentes de tipado en el test file raíz (`fields.update(overrides)`, Optional subscript) — CI no type-chequea tests.

### What's next

- Security-auditor y QA-tester sobre este PR (pipeline externo).
- Opcional: auditoría de `list_reports(owner="")` a nivel storage (endpoint ya protege via 422 en `_owner_scope`; solo relevante si aparecen nuevos callers directos).
- Opcional: cleanup UP017 del dashboard test file en un chore aparte.