### PR TITLE
feat(security): refresh token rotation + reuse detection (jti+Redis) + /auth/revoke — F-2, OWASP API2 (card 3ae2e5c1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Refresh token rotation + reuse detection (card 3ae2e5c1, finding F-2,
+  OWASP API2)**: new self-contained module
+  `src/infrastructure/refresh_tokens` (vendored verbatim into
+  `dashboard/backend/src/infrastructure/refresh_tokens` with a parity
+  guard test, same pattern as `qa_visual`). Refresh tokens now carry a
+  unique `jti` per emission plus a `fam` (family) identifier. Every
+  successful refresh rotates the pair (new access + new refresh) and
+  atomically consumes the old `jti` in Redis (SET NX EX, TTL = remaining
+  token lifetime). Replaying a consumed token answers 401, revokes the
+  whole token family (descendants included) and raises a SECURITY alarm
+  log; tokens from a revoked family are rejected outright. Explicit
+  logout via `POST /auth/revoke` (RFC 7009-style, idempotent). Redis
+  connection details come exclusively from environment settings — no
+  hardcoded credentials. If Redis is unavailable, refresh fails CLOSED
+  (503) so the denylist cannot be bypassed. Legacy pre-`jti` tokens are
+  upgraded once and keep working until their own expiry.
+
 - **Supply-chain R3 — deploy security gates (fail-closed)**: production and
   preview deploys are now GATED by a blocking `security-gate` job in
   `deploy-railway.yml` and `pr-deploy-coolify.yml` (card 650387a1):

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -8,6 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+#### Refresh Token Rotation (card 3ae2e5c1, F-2 / OWASP API2)
+- **Rotating refresh tokens with reuse detection**: `services/auth_service.py`
+  mints refresh tokens with a unique `jti` and a `fam` (family) claim via
+  the new vendored `src/infrastructure/refresh_tokens` store (Redis-backed
+  jti denylist + family tombstones; parity-guarded against the repo-level
+  module)
+  - `POST /auth/refresh` now ROTATES: returns a new access + refresh pair,
+    atomically consumes the old `jti` (SET NX EX, TTL = remaining lifetime)
+  - REUSE DETECTION: replaying a consumed token returns 401, revokes the
+    entire token family and logs a SECURITY alarm; members of a revoked
+    family are always rejected
+  - New `POST /auth/revoke`: explicit server-side logout (RFC 7009-style,
+    idempotent; invalid/expired tokens still return 200)
+  - Fail-closed: refresh answers 503 when Redis is unavailable (the
+    denylist can never be bypassed by an outage)
+  - Legacy tokens without `jti` are upgraded once and expire naturally
+  - `tests/conftest.py`: the global redis mock now keeps
+    `redis.exceptions` importable (also un-breaks 10 pre-existing
+    `test_test_cache.py` failures)
+  - Redis credentials come only from env (`REDIS_HOST`/`REDIS_PORT`/
+    `REDIS_PASSWORD`); tests use local `127.0.0.1:6379` DB 15 with a
+    dedicated prefix and skip when Redis is absent
+
 #### Secrets Remediation
 - **Removed hardcoded Railway Redis credentials from the repository**: the
   production credential was embedded in test fixtures and docs

--- a/dashboard/backend/api/v1/auth_routes.py
+++ b/dashboard/backend/api/v1/auth_routes.py
@@ -10,10 +10,21 @@ from typing import List
 from database import get_db_session
 from services.oauth_service import oauth_service, OAuthService
 from services.api_key_service import api_key_service, get_user_from_api_key
-from services.auth_service import login_for_access_token, get_current_user
+from services.auth_service import (
+    login_for_access_token,
+    get_current_user,
+    revoke_refresh_token,
+)
 from schemas import (
-    LoginRequest, TokenResponse, OAuthLoginRequest, OAuthUrlResponse,
-    ApiKeyCreate, ApiKeyResponse, UserCreate, UserResponse, RefreshTokenRequest
+    LoginRequest,
+    TokenResponse,
+    OAuthLoginRequest,
+    OAuthUrlResponse,
+    ApiKeyCreate,
+    ApiKeyResponse,
+    UserCreate,
+    UserResponse,
+    RefreshTokenRequest,
 )
 from models import User
 from core.logging_config import get_logger
@@ -31,20 +42,18 @@ async def login(login_request: LoginRequest, db: AsyncSession = Depends(get_db_s
 
 # User Registration
 @router.post("/register", response_model=UserResponse)
-async def register(
-    user_create: UserCreate,
-    db: AsyncSession = Depends(get_db_session)
-):
+async def register(user_create: UserCreate, db: AsyncSession = Depends(get_db_session)):
     """
     Register a new user with email/password
-    
+
     Args:
         user_create: User registration data (email, username, password)
-        
+
     Returns:
         UserResponse with user info (without password)
     """
     from services.user_service import create_user_service
+
     return await create_user_service(user_create, db)
 
 
@@ -52,20 +61,23 @@ async def register(
 @router.get("/oauth/{provider}/url", response_model=OAuthUrlResponse)
 async def get_oauth_url(provider: str):
     import secrets
+
     state = secrets.token_urlsafe(16)
-    
+
     if provider == "google":
         url = OAuthService.get_google_auth_url(state)
     elif provider == "github":
         url = OAuthService.get_github_auth_url(state)
     else:
         raise HTTPException(status_code=400, detail=f"Unsupported provider: {provider}")
-    
+
     return OAuthUrlResponse(provider=provider, authorization_url=url, state=state)
 
 
 @router.post("/oauth/callback", response_model=TokenResponse)
-async def oauth_callback(oauth_request: OAuthLoginRequest, db: AsyncSession = Depends(get_db_session)):
+async def oauth_callback(
+    oauth_request: OAuthLoginRequest, db: AsyncSession = Depends(get_db_session)
+):
     return await oauth_service.oauth_login(db, oauth_request)
 
 
@@ -76,7 +88,7 @@ async def oauth_callback(oauth_request: OAuthLoginRequest, db: AsyncSession = De
 async def create_api_key(
     key_request: ApiKeyCreate,
     current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db_session)
+    db: AsyncSession = Depends(get_db_session),
 ):
     """Create API key for current user (REQUIRES JWT authentication)"""
     return await api_key_service.create_api_key(db, current_user.id, key_request)
@@ -84,8 +96,7 @@ async def create_api_key(
 
 @router.get("/api-keys", response_model=List[ApiKeyResponse])
 async def list_api_keys(
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db_session)
+    current_user: User = Depends(get_current_user), db: AsyncSession = Depends(get_db_session)
 ):
     """List API keys for current user (REQUIRES JWT authentication)"""
     return await api_key_service.list_api_keys(db, current_user.id)
@@ -95,7 +106,7 @@ async def list_api_keys(
 async def revoke_api_key(
     key_id: str,
     current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db_session)
+    db: AsyncSession = Depends(get_db_session),
 ):
     """Revoke API key for current user (REQUIRES JWT authentication)"""
     success = await api_key_service.revoke_api_key(db, current_user.id, key_id)
@@ -107,21 +118,32 @@ async def revoke_api_key(
 # Session Management
 @router.post("/refresh", response_model=TokenResponse)
 async def refresh_token(
-    refresh_request: RefreshTokenRequest,
-    db: AsyncSession = Depends(get_db_session)
+    refresh_request: RefreshTokenRequest, db: AsyncSession = Depends(get_db_session)
 ):
     """Refresh access token using refresh token"""
     from services.auth_service import refresh_access_token
-    
+
     return await refresh_access_token(refresh_request.refresh_token, db)
 
 
+@router.post("/revoke")
+async def revoke_token(refresh_request: RefreshTokenRequest):
+    """Explicit logout: revoke a refresh token server-side (RFC 7009-style).
+
+    The presented refresh token is denylisted and its token family
+    tombstoned, so rotated descendants die too. Idempotent: unknown or
+    already-invalid tokens still return 200 (they reveal nothing).
+    """
+    revoked = await revoke_refresh_token(refresh_request.refresh_token)
+    if revoked:
+        return {"message": "Refresh token revoked", "revoked": True}
+    return {"message": "No refresh token revoked (unknown or expired)", "revoked": False}
+
+
 @router.post("/logout")
-async def logout(
-    current_user: User = Depends(get_current_user)
-):
+async def logout(current_user: User = Depends(get_current_user)):
     """Logout current user (client should discard token)"""
     logger.info("User logged out", user_id=current_user.id, username=current_user.username)
-    # Note: JWT tokens are stateless, so logout is handled client-side by discarding the token
-    # For more advanced logout (token blacklist), implement Redis-based token blacklist
+    # Server-side revocation of the refresh token family lives in
+    # POST /auth/revoke; this endpoint remains the client-side discard.
     return {"message": "Logout successful. Please discard your tokens."}

--- a/dashboard/backend/services/auth_service.py
+++ b/dashboard/backend/services/auth_service.py
@@ -2,10 +2,17 @@
 Authentication Service
 
 Provides JWT token generation and validation, password hashing, and user authentication.
+
+Refresh tokens rotate on every use (OWASP API2): each carries a unique
+``jti`` plus a ``fam`` (family) identifier, consumed tokens are denied in
+Redis until their own expiry, and replaying a consumed token revokes the
+whole family with a security alarm.
 """
 
+import time
 from datetime import datetime, timedelta
 from typing import Optional
+from uuid import uuid4
 
 from database import get_db_session
 from fastapi import Depends, HTTPException, status
@@ -20,12 +27,43 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from config import settings
 from core.logging_config import get_logger, set_request_id
 from src.infrastructure.qa_visual.models import QAVisualPrincipal
+from src.infrastructure.refresh_tokens.store import (
+    RefreshTokenStore,
+    TokenStoreUnavailableError,
+)
 
 # Initialize logger
 logger = get_logger(__name__)
 
 # Password hashing
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+# Refresh token rotation constants (card 3ae2e5c1, F-2 / OWASP API2)
+REFRESH_TOKEN_LIFETIME = timedelta(days=7)
+# A family tombstone only needs to outlive the longest-lived member of the
+# family, which is bounded by the refresh token lifetime itself.
+FAMILY_REVOCATION_TTL_SECONDS = int(REFRESH_TOKEN_LIFETIME.total_seconds())
+
+_refresh_token_store: RefreshTokenStore | None = None
+
+
+def _redis_url_from_settings() -> str:
+    """Build the Redis URL from environment-driven settings only.
+
+    Credentials are never hardcoded: REDIS_PASSWORD comes exclusively from
+    the environment (unset for local/CI deployments on 127.0.0.1).
+    """
+    password_part = f":{settings.redis_password}@" if settings.redis_password else ""
+    return f"redis://{password_part}{settings.redis_host}:{settings.redis_port}/0"
+
+
+def get_refresh_token_store() -> RefreshTokenStore:
+    """Lazily create the shared refresh token store (Redis denylist)."""
+    global _refresh_token_store
+    if _refresh_token_store is None:
+        _refresh_token_store = RefreshTokenStore(url=_redis_url_from_settings())
+    return _refresh_token_store
+
 
 # L-1: only these values of the ``type`` claim may authenticate access
 # endpoints. ``None`` keeps tokens minted before the type tag valid;
@@ -163,24 +201,55 @@ async def login_for_access_token(auth_request: LoginRequest, db: AsyncSession) -
     )
 
 
-def create_refresh_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
-    """Create a refresh token with longer expiry"""
+def create_refresh_token(
+    data: dict,
+    expires_delta: Optional[timedelta] = None,
+    family_id: str | None = None,
+) -> str:
+    """Create a rotating refresh token with a unique ``jti`` per emission.
+
+    Every token also carries a ``fam`` (family) identifier: fresh at login,
+    inherited across rotations so a detected reuse can revoke the whole
+    family (OWASP API2).
+    """
     to_encode = data.copy()
     if expires_delta:
         expire = datetime.utcnow() + expires_delta
     else:
-        # Default refresh token expiry: 7 days
-        expire = datetime.utcnow() + timedelta(days=7)
+        expire = datetime.utcnow() + REFRESH_TOKEN_LIFETIME
 
-    to_encode.update({"exp": expire, "type": "refresh"})
+    to_encode.update(
+        {
+            "exp": expire,
+            "type": "refresh",
+            "jti": str(uuid4()),
+            "fam": family_id or str(uuid4()),
+        }
+    )
     encoded_jwt = jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
     logger.debug("Refresh token created", expiry=expire.isoformat())
     return encoded_jwt
 
 
-async def refresh_access_token(refresh_token: str, db: AsyncSession) -> TokenResponse:
-    """Refresh access token using refresh token"""
+async def refresh_access_token(
+    refresh_token: str,
+    db: AsyncSession,
+    store: RefreshTokenStore | None = None,
+) -> TokenResponse:
+    """Rotate a refresh token: issue a new pair and deny the consumed one.
+
+    OWASP API2 hardening (card 3ae2e5c1, F-2):
+
+    - every successful refresh mints a NEW access + refresh token pair and
+      denylists the consumed ``jti`` in Redis (TTL = remaining lifetime);
+    - replaying a consumed token answers 401, revokes its whole family and
+      raises a security alarm log;
+    - tokens from an already-revoked family are rejected outright;
+    - if the Redis store is unavailable the refresh fails CLOSED (503):
+      a denylist that cannot be checked must not be bypassed.
+    """
     logger.info("Refreshing access token")
+    token_store = store if store is not None else get_refresh_token_store()
 
     try:
         payload = jwt.decode(
@@ -219,11 +288,67 @@ async def refresh_access_token(refresh_token: str, db: AsyncSession) -> TokenRes
                 headers={"WWW-Authenticate": "Bearer"},
             )
 
-        # Create new access token
+        jti = payload.get("jti")
+        family_id = payload.get("fam")
+
+        # Family already revoked: any presentation is a replay attempt.
+        if family_id and await token_store.is_family_revoked(family_id):
+            logger.error(
+                "SECURITY: refresh token presented for revoked family "
+                "(possible replay or stolen token)",
+                username=username,
+                jti=jti,
+                fam=family_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid refresh token",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        # Reuse detection: atomically consume the jti. If it was already
+        # consumed (SET-NX lost the race or an outright replay), revoke
+        # the whole family and raise the security alarm.
+        if jti is not None:
+            exp = payload.get("exp")
+            remaining_seconds = max(1, int(exp - time.time())) if exp else 1
+            consumed = await token_store.try_consume_jti(jti, ttl_seconds=remaining_seconds)
+            if not consumed:
+                if family_id:
+                    await token_store.revoke_family(
+                        family_id, ttl_seconds=FAMILY_REVOCATION_TTL_SECONDS
+                    )
+                logger.error(
+                    "SECURITY: refresh token reuse detected - token family revoked",
+                    username=username,
+                    jti=jti,
+                    fam=family_id,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Invalid refresh token",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+
+        if jti is None:
+            # Tokens minted before rotation shipped carry no jti; upgrade
+            # them once (they cannot be denylisted, but they still expire).
+            logger.warning(
+                "Legacy refresh token without jti accepted for one-time upgrade",
+                username=username,
+            )
+
+        # ROTATION complete: the consumed jti is denied until its own
+        # expiry; mint a fresh pair (same family, new jti).
+        new_refresh = create_refresh_token({"sub": user.username}, family_id=family_id)
         access_token = create_access_token(data={"sub": user.username})
         logger.info("Access token refreshed successfully", username=username)
 
-        return TokenResponse(access_token=access_token, token_type="bearer")
+        return TokenResponse(
+            access_token=access_token,
+            token_type="bearer",
+            refresh_token=new_refresh,
+        )
 
     except JWTError as e:
         logger.warning("Refresh token validation failed", error=str(e))
@@ -231,6 +356,64 @@ async def refresh_access_token(refresh_token: str, db: AsyncSession) -> TokenRes
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid refresh token",
             headers={"WWW-Authenticate": "Bearer"},
+        )
+    except TokenStoreUnavailableError:
+        # Fail CLOSED: without the denylist, reuse cannot be detected.
+        logger.error("Token store unavailable - refusing refresh (fail closed)")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Token store unavailable",
+        )
+
+
+async def revoke_refresh_token(
+    refresh_token: str,
+    store: RefreshTokenStore | None = None,
+) -> bool:
+    """Explicitly revoke a refresh token (RFC 7009-style logout).
+
+    Revoking the presented token also tombstones its family, so every
+    descendant from earlier rotations dies with it. Invalid, expired or
+    legacy (pre-``jti``) tokens are not errors: the call is idempotent
+    and simply reports that nothing was revoked.
+    """
+    token_store = store if store is not None else get_refresh_token_store()
+    try:
+        try:
+            payload = jwt.decode(
+                refresh_token,
+                settings.secret_key,
+                algorithms=[settings.algorithm],
+            )
+        except JWTError:
+            logger.info("Revoke requested for invalid refresh token - ignored")
+            return False
+
+        if payload.get("type") != "refresh":
+            logger.info("Revoke requested for non-refresh token - ignored")
+            return False
+
+        jti = payload.get("jti")
+        family_id = payload.get("fam")
+
+        if not jti:
+            logger.warning(
+                "Legacy refresh token cannot be revoked server-side",
+                username=payload.get("sub"),
+            )
+            return False
+
+        remaining_seconds = max(1, int(payload.get("exp", time.time() + 1) - time.time()))
+        await token_store.deny_jti(jti, ttl_seconds=remaining_seconds)
+        if family_id:
+            await token_store.revoke_family(family_id, ttl_seconds=FAMILY_REVOCATION_TTL_SECONDS)
+        logger.info("Refresh token revoked", username=payload.get("sub"), jti=jti)
+        return True
+    except TokenStoreUnavailableError:
+        logger.error("Token store unavailable during revoke")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Token store unavailable",
         )
 
 

--- a/dashboard/backend/src/infrastructure/refresh_tokens/__init__.py
+++ b/dashboard/backend/src/infrastructure/refresh_tokens/__init__.py
@@ -1,0 +1,14 @@
+"""Redis-backed state for refresh token rotation and reuse detection.
+
+Self-contained module (no repo-level config dependencies) so it can be
+vendored verbatim into the dashboard backend build context, mirroring the
+``qa_visual`` vendor pattern.
+"""
+
+from .store import DEFAULT_PREFIX, RefreshTokenStore, TokenStoreUnavailableError
+
+__all__ = [
+    "DEFAULT_PREFIX",
+    "RefreshTokenStore",
+    "TokenStoreUnavailableError",
+]

--- a/dashboard/backend/src/infrastructure/refresh_tokens/store.py
+++ b/dashboard/backend/src/infrastructure/refresh_tokens/store.py
@@ -1,0 +1,120 @@
+"""Redis-backed refresh token store (card 3ae2e5c1, finding F-2, OWASP API2).
+
+Holds the server-side state required for secure refresh token rotation:
+
+- **jti denylist**: every consumed refresh token is denied by its unique
+  ``jti`` until the token itself would have expired (TTL = remaining
+  lifetime), so replaying a rotated token is detected and rejected.
+- **family tombstones**: when reuse is detected the whole token family is
+  revoked, killing every descendant minted by later rotations.
+
+The store is deliberately dependency-light: a Redis client is either
+injected (tests, alternate wiring) or lazily created from a URL. It never
+reads configuration itself, so no credentials can be hardcoded here and
+each deployment decides where the connection details come from.
+
+All Redis failures surface as :class:`TokenStoreUnavailableError` so
+callers can fail closed (refuse the refresh) instead of accidentally
+accepting a token whose denylist could not be checked.
+"""
+
+from redis import asyncio as aioredis
+from redis.exceptions import RedisError
+
+DEFAULT_PREFIX = "qa:auth:rt"
+
+
+class TokenStoreUnavailableError(RuntimeError):
+    """The token store (Redis) is unreachable or failed mid-operation."""
+
+
+class RefreshTokenStore:
+    """Denylist + family-revocation store for rotating refresh tokens."""
+
+    def __init__(
+        self,
+        client: "aioredis.Redis | None" = None,
+        url: str | None = None,
+        prefix: str = DEFAULT_PREFIX,
+    ) -> None:
+        if client is None and url is None:
+            raise ValueError("either a redis client or a redis url is required")
+        if client is None:
+            assert url is not None  # narrowed by the check above
+            client = aioredis.from_url(url)
+        self.client = client
+        self.prefix = prefix
+
+    def _jti_key(self, jti: str) -> str:
+        return f"{self.prefix}:jti:{jti}"
+
+    def _fam_key(self, family_id: str) -> str:
+        return f"{self.prefix}:fam:{family_id}"
+
+    async def deny_jti(self, jti: str, ttl_seconds: int) -> None:
+        """Deny a refresh token by ``jti`` until its own expiry passes."""
+        ttl = max(1, int(ttl_seconds))
+        try:
+            await self.client.setex(self._jti_key(jti), ttl, "1")
+        except RedisError as exc:
+            raise TokenStoreUnavailableError(f"redis setex failed: {exc}") from exc
+
+    async def try_consume_jti(self, jti: str, ttl_seconds: int) -> bool:
+        """Atomically deny ``jti`` unless it was already consumed.
+
+        Returns True when this call consumed the token (first use) and
+        False when the jti was already denied (replay). The SET-NX-EX
+        round-trip makes the check-and-deny step atomic, closing the
+        race where two concurrent refreshes with the same token both
+        pass a separate exists() check and both rotate.
+        """
+        ttl = max(1, int(ttl_seconds))
+        try:
+            was_set = await self.client.set(self._jti_key(jti), "1", ex=ttl, nx=True)
+        except RedisError as exc:
+            raise TokenStoreUnavailableError(f"redis set(nx) failed: {exc}") from exc
+        return bool(was_set)
+
+    async def is_denied(self, jti: str) -> bool:
+        try:
+            return bool(await self.client.exists(self._jti_key(jti)))
+        except RedisError as exc:
+            raise TokenStoreUnavailableError(f"redis exists failed: {exc}") from exc
+
+    async def revoke_family(self, family_id: str, ttl_seconds: int) -> None:
+        """Tombstone a token family; every member is rejected afterwards.
+
+        The TTL bounds the tombstone to the maximum possible refresh token
+        lifetime so the key self-cleans once the family could no longer be
+        alive anyway.
+        """
+        ttl = max(1, int(ttl_seconds))
+        try:
+            await self.client.setex(self._fam_key(family_id), ttl, "1")
+        except RedisError as exc:
+            raise TokenStoreUnavailableError(f"redis setex failed: {exc}") from exc
+
+    async def is_family_revoked(self, family_id: str) -> bool:
+        try:
+            return bool(await self.client.exists(self._fam_key(family_id)))
+        except RedisError as exc:
+            raise TokenStoreUnavailableError(f"redis exists failed: {exc}") from exc
+
+    async def ping(self) -> bool:
+        try:
+            return bool(await self.client.ping())
+        except RedisError as exc:
+            raise TokenStoreUnavailableError(f"redis ping failed: {exc}") from exc
+
+    async def aclose(self) -> None:
+        try:
+            await self.client.aclose()
+        except AttributeError:
+            # Older redis-py versions name the close method differently.
+            close = getattr(self.client, "close", None)
+            if close is not None:
+                result = close()
+                if result is not None and hasattr(result, "__await__"):
+                    await result
+        except RedisError:
+            pass

--- a/dashboard/backend/tests/conftest.py
+++ b/dashboard/backend/tests/conftest.py
@@ -17,6 +17,12 @@ _mock_redis.Redis = MagicMock(return_value=MagicMock(ping=MagicMock(return_value
 _mock_redis.from_url = MagicMock(return_value=MagicMock(ping=MagicMock(return_value=True)))
 sys.modules.setdefault("redis", _mock_redis)
 sys.modules.setdefault("redis.asyncio", MagicMock())
+# Keep ``from redis.exceptions import RedisError`` importable under the
+# mock (used by the refresh-token store); Exception keeps except-clauses
+# functional. Suites that need the REAL client pop these entries first.
+_mock_exceptions = MagicMock()
+_mock_exceptions.RedisError = Exception
+sys.modules.setdefault("redis.exceptions", _mock_exceptions)
 
 # Add the backend directory to Python path
 backend_dir = Path(__file__).parent.parent

--- a/dashboard/backend/tests/unit/test_refresh_rotation.py
+++ b/dashboard/backend/tests/unit/test_refresh_rotation.py
@@ -1,0 +1,310 @@
+"""Refresh token rotation, reuse detection and revocation (card 3ae2e5c1, F-2).
+
+OWASP API2 hardening for the dashboard auth service:
+
+- ROTATION: every successful refresh mints a NEW access + refresh token
+  pair and invalidates the consumed refresh token (jti denylist in Redis,
+  TTL = remaining token lifetime).
+- REUSE DETECTION: replaying a consumed refresh token answers 401,
+  revokes the whole token family (so rotated descendants die too) and
+  raises a security alarm log.
+- REVOKE: POST /auth/revoke implements RFC 7009-style explicit logout.
+
+These tests run against a REAL local Redis (127.0.0.1:6379, no
+credentials) on a dedicated database with a test-only key prefix. The
+dashboard conftest replaces ``redis`` with a MagicMock before any
+import; we drop that mock here because the real client behaviour is
+exactly what these tests must exercise.
+"""
+
+import logging
+import sys
+from datetime import timedelta
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+# Drop conftest's global redis mock and bind the real client BEFORE the
+# auth service / store get imported by anything below.
+for _mod in ("redis", "redis.asyncio", "redis.exceptions"):
+    sys.modules.pop(_mod, None)
+
+import redis.asyncio as aioredis
+
+pytest.importorskip("jose")
+
+from fastapi import HTTPException
+from jose import jwt
+from models import User
+from schemas import LoginRequest
+from services.auth_service import (
+    create_refresh_token,
+    login_for_access_token,
+    refresh_access_token,
+    revoke_refresh_token,
+)
+
+from config import settings
+from src.infrastructure.refresh_tokens.store import (
+    RefreshTokenStore,
+    TokenStoreUnavailableError,
+)
+
+TEST_REDIS_URL = "redis://127.0.0.1:6379/15"
+TEST_PREFIX = "qa:test:auth"
+
+
+def _redis_available() -> bool:
+    import redis
+
+    try:
+        client = redis.from_url(TEST_REDIS_URL, socket_connect_timeout=1)
+        client.ping()
+        client.close()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _redis_available(), reason="local Redis not available")
+
+
+async def _purge_test_keys(store: RefreshTokenStore) -> None:
+    async for key in store.client.scan_iter(f"{TEST_PREFIX}:*"):
+        await store.client.delete(key)
+
+
+@pytest.fixture
+async def store():
+    client = aioredis.from_url(TEST_REDIS_URL)
+    s = RefreshTokenStore(client=client, prefix=TEST_PREFIX)
+    await _purge_test_keys(s)
+    yield s
+    await _purge_test_keys(s)
+    await s.aclose()
+
+
+def make_user(**overrides) -> User:
+    fields = dict(
+        id=1,
+        username="testuser",
+        email="test@example.com",
+        hashed_password="x",
+        is_active=True,
+        is_superuser=False,
+    )
+    fields.update(overrides)
+    return User(**fields)
+
+
+def make_db(user: User | None) -> AsyncMock:
+    mock_db = AsyncMock()
+    mock_result = AsyncMock()
+    mock_result.scalar_one_or_none = Mock(return_value=user)
+    mock_db.execute = AsyncMock(return_value=mock_result)
+    return mock_db
+
+
+def decode(token: str) -> dict:
+    return jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+
+
+def make_broken_store() -> RefreshTokenStore:
+    broken = Mock()
+    broken.is_denied = AsyncMock(side_effect=TokenStoreUnavailableError("down"))
+    broken.is_family_revoked = AsyncMock(side_effect=TokenStoreUnavailableError("down"))
+    broken.deny_jti = AsyncMock(side_effect=TokenStoreUnavailableError("down"))
+    broken.revoke_family = AsyncMock(side_effect=TokenStoreUnavailableError("down"))
+    broken.try_consume_jti = AsyncMock(side_effect=TokenStoreUnavailableError("down"))
+    return broken
+
+
+class TestJtiClaims:
+    """Requirement 1: refresh tokens carry a unique jti per emission."""
+
+    async def test_refresh_token_has_jti_and_family(self):
+        payload = decode(create_refresh_token({"sub": "testuser"}))
+        assert payload["type"] == "refresh"
+        assert payload["jti"]
+        assert payload["fam"]
+
+    async def test_jti_unique_per_emission(self):
+        first = decode(create_refresh_token({"sub": "testuser"}))
+        second = decode(create_refresh_token({"sub": "testuser"}))
+        assert first["jti"] != second["jti"]
+        assert first["fam"] != second["fam"]
+
+    async def test_login_mints_jti_refresh_token(self, monkeypatch):
+        # Password verification is passlib/bcrypt territory and unrelated
+        # to what this suite asserts (token claims), so stub the lookup.
+        from services import auth_service
+
+        user = make_user()
+        monkeypatch.setattr(auth_service, "authenticate_user", AsyncMock(return_value=user))
+        request = LoginRequest(username="testuser", password="pw")
+        response = await login_for_access_token(request, make_db(user))
+        payload = decode(response.refresh_token)
+        assert payload["jti"]
+        assert payload["fam"]
+
+
+class TestRotation:
+    """Requirement 2: use refresh -> new access+refresh, old one invalidated."""
+
+    async def test_rotation_returns_new_token_pair(self, store):
+        old_refresh = create_refresh_token({"sub": "testuser"})
+        response = await refresh_access_token(old_refresh, make_db(make_user()), store=store)
+        assert response.access_token
+        assert response.refresh_token
+        assert response.refresh_token != old_refresh
+        # the new access token is a valid access token
+        assert decode(response.access_token)["type"] == "access"
+        # the new refresh token carries fresh jti but SAME family
+        old_payload, new_payload = decode(old_refresh), decode(response.refresh_token)
+        assert new_payload["jti"] != old_payload["jti"]
+        assert new_payload["fam"] == old_payload["fam"]
+
+    async def test_used_jti_denied_after_rotation(self, store):
+        old_refresh = create_refresh_token({"sub": "testuser"})
+        old_jti = decode(old_refresh)["jti"]
+        await refresh_access_token(old_refresh, make_db(make_user()), store=store)
+        assert await store.is_denied(old_jti) is True
+
+    async def test_rotated_token_is_usable(self, store):
+        """The fresh refresh token must work for the next cycle."""
+        first = create_refresh_token({"sub": "testuser"})
+        response = await refresh_access_token(first, make_db(make_user()), store=store)
+        second = await refresh_access_token(
+            response.refresh_token, make_db(make_user()), store=store
+        )
+        assert second.refresh_token
+
+    async def test_denylist_ttl_matches_remaining_lifetime(self, store):
+        old_refresh = create_refresh_token({"sub": "testuser"}, expires_delta=timedelta(seconds=90))
+        jti = decode(old_refresh)["jti"]
+        await refresh_access_token(old_refresh, make_db(make_user()), store=store)
+        pttl = await store.client.pttl(f"{TEST_PREFIX}:jti:{jti}")
+        assert 0 < pttl <= 90 * 1000
+
+
+class TestReuseDetection:
+    """Requirement 3: replaying a consumed token -> 401 + family revoked + alarm."""
+
+    async def test_reuse_answered_401(self, store):
+        old_refresh = create_refresh_token({"sub": "testuser"})
+        await refresh_access_token(old_refresh, make_db(make_user()), store=store)
+        with pytest.raises(HTTPException) as exc_info:
+            await refresh_access_token(old_refresh, make_db(make_user()), store=store)
+        assert exc_info.value.status_code == 401
+
+    async def test_reuse_revokes_whole_family(self, store):
+        """The legitimately-rotated descendant must die with the reused token."""
+        first = create_refresh_token({"sub": "testuser"})
+        response = await refresh_access_token(first, make_db(make_user()), store=store)
+        fam = decode(first)["fam"]
+        # replay the consumed token
+        with pytest.raises(HTTPException):
+            await refresh_access_token(first, make_db(make_user()), store=store)
+        assert await store.is_family_revoked(fam) is True
+        # the still-fresh rotated token is now dead too
+        with pytest.raises(HTTPException) as exc_info:
+            await refresh_access_token(response.refresh_token, make_db(make_user()), store=store)
+        assert exc_info.value.status_code == 401
+
+    async def test_reuse_raises_security_alarm(self, store, caplog):
+        first = create_refresh_token({"sub": "testuser"})
+        await refresh_access_token(first, make_db(make_user()), store=store)
+        with caplog.at_level(logging.ERROR, logger="services.auth_service"):
+            with pytest.raises(HTTPException):
+                await refresh_access_token(first, make_db(make_user()), store=store)
+        assert any(
+            "reuse" in record.message.lower() and "refresh" in record.message.lower()
+            for record in caplog.records
+        ), f"expected reuse alarm log, got: {[r.message for r in caplog.records]}"
+
+
+class TestRevoke:
+    """Requirement 4: explicit logout revokes the presented refresh token."""
+
+    async def test_revoke_denies_token(self, store):
+        token = create_refresh_token({"sub": "testuser"})
+        revoked = await revoke_refresh_token(token, store=store)
+        assert revoked is True
+        with pytest.raises(HTTPException) as exc_info:
+            await refresh_access_token(token, make_db(make_user()), store=store)
+        assert exc_info.value.status_code == 401
+
+    async def test_revoke_kills_family_descendants(self, store):
+        parent = create_refresh_token({"sub": "testuser"})
+        response = await refresh_access_token(parent, make_db(make_user()), store=store)
+        await revoke_refresh_token(parent, store=store)
+        with pytest.raises(HTTPException):
+            await refresh_access_token(response.refresh_token, make_db(make_user()), store=store)
+
+    async def test_revoke_invalid_token_is_not_an_error(self, store):
+        """RFC 7009: revoking an unknown/invalid token still succeeds."""
+        assert await revoke_refresh_token("not-a-jwt", store=store) is False
+        expired = create_refresh_token({"sub": "testuser"}, expires_delta=timedelta(minutes=-5))
+        assert await revoke_refresh_token(expired, store=store) is False
+
+
+class TestLegacyMigration:
+    """Tokens minted before this change (no jti) refresh once and upgrade."""
+
+    async def test_legacy_token_upgrades_to_jti_token(self, store):
+        legacy = jwt.encode(
+            {
+                "sub": "testuser",
+                "type": "refresh",
+                "exp": decode(create_refresh_token({"sub": "x"}))["exp"],
+            },
+            settings.secret_key,
+            algorithm=settings.algorithm,
+        )
+        response = await refresh_access_token(legacy, make_db(make_user()), store=store)
+        payload = decode(response.refresh_token)
+        assert payload["jti"]
+        assert payload["fam"]
+
+
+class TestStoreFailure:
+    """Fail-closed: refresh is refused (503) when the denylist is unreachable."""
+
+    async def test_refresh_fails_closed_without_store(self):
+        token = create_refresh_token({"sub": "testuser"})
+        with pytest.raises(HTTPException) as exc_info:
+            await refresh_access_token(token, make_db(make_user()), store=make_broken_store())
+        assert exc_info.value.status_code == 503
+
+    async def test_reuse_detection_cannot_be_bypassed_by_store_outage(self):
+        """A revoked family must not refresh just because Redis went down."""
+        token = create_refresh_token({"sub": "testuser"})
+        broken = make_broken_store()
+        broken.is_family_revoked = AsyncMock(return_value=True)
+        with pytest.raises(HTTPException) as exc_info:
+            await refresh_access_token(token, make_db(make_user()), store=broken)
+        assert exc_info.value.status_code == 401
+
+
+class TestRoute:
+    """POST /auth/revoke endpoint wiring."""
+
+    async def test_revoke_endpoint_registered(self):
+        from api.v1.auth_routes import router
+
+        paths = {route.path for route in router.routes}
+        assert "/auth/revoke" in paths
+
+    async def test_revoke_endpoint_calls_service(self, store, monkeypatch):
+        from api.v1 import auth_routes
+
+        called = {}
+
+        async def fake_revoke(token: str, store=None):
+            called["token"] = token
+            return True
+
+        monkeypatch.setattr(auth_routes, "revoke_refresh_token", fake_revoke)
+        response = await auth_routes.revoke_token(refresh_request=Mock(refresh_token="abc"))
+        assert called["token"] == "abc"
+        assert response["revoked"] is True

--- a/src/infrastructure/refresh_tokens/__init__.py
+++ b/src/infrastructure/refresh_tokens/__init__.py
@@ -1,0 +1,14 @@
+"""Redis-backed state for refresh token rotation and reuse detection.
+
+Self-contained module (no repo-level config dependencies) so it can be
+vendored verbatim into the dashboard backend build context, mirroring the
+``qa_visual`` vendor pattern.
+"""
+
+from .store import DEFAULT_PREFIX, RefreshTokenStore, TokenStoreUnavailableError
+
+__all__ = [
+    "DEFAULT_PREFIX",
+    "RefreshTokenStore",
+    "TokenStoreUnavailableError",
+]

--- a/src/infrastructure/refresh_tokens/store.py
+++ b/src/infrastructure/refresh_tokens/store.py
@@ -1,0 +1,120 @@
+"""Redis-backed refresh token store (card 3ae2e5c1, finding F-2, OWASP API2).
+
+Holds the server-side state required for secure refresh token rotation:
+
+- **jti denylist**: every consumed refresh token is denied by its unique
+  ``jti`` until the token itself would have expired (TTL = remaining
+  lifetime), so replaying a rotated token is detected and rejected.
+- **family tombstones**: when reuse is detected the whole token family is
+  revoked, killing every descendant minted by later rotations.
+
+The store is deliberately dependency-light: a Redis client is either
+injected (tests, alternate wiring) or lazily created from a URL. It never
+reads configuration itself, so no credentials can be hardcoded here and
+each deployment decides where the connection details come from.
+
+All Redis failures surface as :class:`TokenStoreUnavailableError` so
+callers can fail closed (refuse the refresh) instead of accidentally
+accepting a token whose denylist could not be checked.
+"""
+
+from redis import asyncio as aioredis
+from redis.exceptions import RedisError
+
+DEFAULT_PREFIX = "qa:auth:rt"
+
+
+class TokenStoreUnavailableError(RuntimeError):
+    """The token store (Redis) is unreachable or failed mid-operation."""
+
+
+class RefreshTokenStore:
+    """Denylist + family-revocation store for rotating refresh tokens."""
+
+    def __init__(
+        self,
+        client: "aioredis.Redis | None" = None,
+        url: str | None = None,
+        prefix: str = DEFAULT_PREFIX,
+    ) -> None:
+        if client is None and url is None:
+            raise ValueError("either a redis client or a redis url is required")
+        if client is None:
+            assert url is not None  # narrowed by the check above
+            client = aioredis.from_url(url)
+        self.client = client
+        self.prefix = prefix
+
+    def _jti_key(self, jti: str) -> str:
+        return f"{self.prefix}:jti:{jti}"
+
+    def _fam_key(self, family_id: str) -> str:
+        return f"{self.prefix}:fam:{family_id}"
+
+    async def deny_jti(self, jti: str, ttl_seconds: int) -> None:
+        """Deny a refresh token by ``jti`` until its own expiry passes."""
+        ttl = max(1, int(ttl_seconds))
+        try:
+            await self.client.setex(self._jti_key(jti), ttl, "1")
+        except RedisError as exc:
+            raise TokenStoreUnavailableError(f"redis setex failed: {exc}") from exc
+
+    async def try_consume_jti(self, jti: str, ttl_seconds: int) -> bool:
+        """Atomically deny ``jti`` unless it was already consumed.
+
+        Returns True when this call consumed the token (first use) and
+        False when the jti was already denied (replay). The SET-NX-EX
+        round-trip makes the check-and-deny step atomic, closing the
+        race where two concurrent refreshes with the same token both
+        pass a separate exists() check and both rotate.
+        """
+        ttl = max(1, int(ttl_seconds))
+        try:
+            was_set = await self.client.set(self._jti_key(jti), "1", ex=ttl, nx=True)
+        except RedisError as exc:
+            raise TokenStoreUnavailableError(f"redis set(nx) failed: {exc}") from exc
+        return bool(was_set)
+
+    async def is_denied(self, jti: str) -> bool:
+        try:
+            return bool(await self.client.exists(self._jti_key(jti)))
+        except RedisError as exc:
+            raise TokenStoreUnavailableError(f"redis exists failed: {exc}") from exc
+
+    async def revoke_family(self, family_id: str, ttl_seconds: int) -> None:
+        """Tombstone a token family; every member is rejected afterwards.
+
+        The TTL bounds the tombstone to the maximum possible refresh token
+        lifetime so the key self-cleans once the family could no longer be
+        alive anyway.
+        """
+        ttl = max(1, int(ttl_seconds))
+        try:
+            await self.client.setex(self._fam_key(family_id), ttl, "1")
+        except RedisError as exc:
+            raise TokenStoreUnavailableError(f"redis setex failed: {exc}") from exc
+
+    async def is_family_revoked(self, family_id: str) -> bool:
+        try:
+            return bool(await self.client.exists(self._fam_key(family_id)))
+        except RedisError as exc:
+            raise TokenStoreUnavailableError(f"redis exists failed: {exc}") from exc
+
+    async def ping(self) -> bool:
+        try:
+            return bool(await self.client.ping())
+        except RedisError as exc:
+            raise TokenStoreUnavailableError(f"redis ping failed: {exc}") from exc
+
+    async def aclose(self) -> None:
+        try:
+            await self.client.aclose()
+        except AttributeError:
+            # Older redis-py versions name the close method differently.
+            close = getattr(self.client, "close", None)
+            if close is not None:
+                result = close()
+                if result is not None and hasattr(result, "__await__"):
+                    await result
+        except RedisError:
+            pass

--- a/tests/unit/infrastructure/test_refresh_token_store.py
+++ b/tests/unit/infrastructure/test_refresh_token_store.py
@@ -1,0 +1,182 @@
+"""Unit tests for the Redis-backed refresh token store (card 3ae2e5c1, F-2).
+
+The store implements the server-side state needed for refresh token
+rotation and reuse detection (OWASP API2):
+
+- ``deny_jti`` / ``is_denied``: denylist of consumed refresh tokens,
+  keyed by the token's unique ``jti``. Entries carry a TTL equal to the
+  token's remaining lifetime so the denylist self-cleans.
+- ``revoke_family`` / ``is_family_revoked``: family tombstones used to
+  kill every descendant of a token family after reuse detection fires.
+
+Tests run against a REAL local Redis (127.0.0.1:6379, no credentials)
+and are skipped when it is unreachable. A dedicated test database and
+key prefix keep them isolated from any other data.
+"""
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from src.infrastructure.refresh_tokens.store import RefreshTokenStore, TokenStoreUnavailableError
+
+TEST_REDIS_URL = "redis://127.0.0.1:6379/15"
+TEST_PREFIX = "qa:test:rt:store"
+
+
+def _redis_available() -> bool:
+    import redis
+
+    try:
+        client = redis.from_url(TEST_REDIS_URL, socket_connect_timeout=1)
+        client.ping()
+        client.close()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _redis_available(), reason="local Redis not available")
+
+
+async def _purge_test_keys(store: RefreshTokenStore) -> None:
+    async for key in store.client.scan_iter(f"{TEST_PREFIX}:*"):
+        await store.client.delete(key)
+
+
+@pytest_asyncio.fixture
+async def store():
+    import redis.asyncio as aioredis
+
+    client = aioredis.from_url(TEST_REDIS_URL)
+    s = RefreshTokenStore(client=client, prefix=TEST_PREFIX)
+    await _purge_test_keys(s)
+    yield s
+    await _purge_test_keys(s)
+    await s.aclose()
+
+
+class TestJtiDenylist:
+    @pytest.mark.asyncio
+    async def test_denied_jti_is_reported(self, store):
+        jti = str(uuid4())
+        assert await store.is_denied(jti) is False
+        await store.deny_jti(jti, ttl_seconds=60)
+        assert await store.is_denied(jti) is True
+
+    @pytest.mark.asyncio
+    async def test_unknown_jti_not_denied(self, store):
+        assert await store.is_denied(str(uuid4())) is False
+
+    @pytest.mark.asyncio
+    async def test_deny_is_idempotent(self, store):
+        jti = str(uuid4())
+        await store.deny_jti(jti, ttl_seconds=60)
+        await store.deny_jti(jti, ttl_seconds=60)
+        assert await store.is_denied(jti) is True
+
+    @pytest.mark.asyncio
+    async def test_deny_sets_ttl(self, store):
+        """The denylist entry must expire with the token, not linger forever."""
+        jti = str(uuid4())
+        await store.deny_jti(jti, ttl_seconds=90)
+        pttl = await store.client.pttl(f"{TEST_PREFIX}:jti:{jti}")
+        assert 0 < pttl <= 90 * 1000
+
+    @pytest.mark.asyncio
+    async def test_denied_jti_expires_after_ttl(self, store):
+        jti = str(uuid4())
+        await store.deny_jti(jti, ttl_seconds=1)
+        await _sleep(1.3)
+        assert await store.is_denied(jti) is False
+
+
+class TestFamilyRevocation:
+    @pytest.mark.asyncio
+    async def test_revoked_family_is_reported(self, store):
+        fam = str(uuid4())
+        assert await store.is_family_revoked(fam) is False
+        await store.revoke_family(fam, ttl_seconds=60)
+        assert await store.is_family_revoked(fam) is True
+
+    @pytest.mark.asyncio
+    async def test_unknown_family_not_revoked(self, store):
+        assert await store.is_family_revoked(str(uuid4())) is False
+
+    @pytest.mark.asyncio
+    async def test_revocation_sets_ttl(self, store):
+        fam = str(uuid4())
+        await store.revoke_family(fam, ttl_seconds=120)
+        pttl = await store.client.pttl(f"{TEST_PREFIX}:fam:{fam}")
+        assert 0 < pttl <= 120 * 1000
+
+
+class TestIsolation:
+    @pytest.mark.asyncio
+    async def test_prefix_isolation(self, store):
+        """Two stores with different prefixes never see each other's keys."""
+        jti = str(uuid4())
+        await store.deny_jti(jti, ttl_seconds=60)
+        other = RefreshTokenStore(client=store.client, prefix=f"{TEST_PREFIX}:other")
+        assert await other.is_denied(jti) is False
+
+
+class TestAtomicConsume:
+    """try_consume_jti closes the concurrent-refresh race via SET NX EX."""
+
+    @pytest.mark.asyncio
+    async def test_first_consume_wins(self, store):
+        jti = str(uuid4())
+        assert await store.try_consume_jti(jti, ttl_seconds=60) is True
+
+    @pytest.mark.asyncio
+    async def test_second_consume_signals_replay(self, store):
+        jti = str(uuid4())
+        await store.try_consume_jti(jti, ttl_seconds=60)
+        assert await store.try_consume_jti(jti, ttl_seconds=60) is False
+
+    @pytest.mark.asyncio
+    async def test_consumed_jti_is_denied(self, store):
+        jti = str(uuid4())
+        await store.try_consume_jti(jti, ttl_seconds=60)
+        assert await store.is_denied(jti) is True
+
+    @pytest.mark.asyncio
+    async def test_consume_sets_ttl(self, store):
+        jti = str(uuid4())
+        await store.try_consume_jti(jti, ttl_seconds=45)
+        pttl = await store.client.pttl(f"{TEST_PREFIX}:jti:{jti}")
+        assert 0 < pttl <= 45 * 1000
+
+
+class TestUnavailableStore:
+    @pytest.mark.asyncio
+    async def test_broken_client_raises_unavailable(self):
+        """Redis errors surface as TokenStoreUnavailableError, never as 500s."""
+        from unittest.mock import AsyncMock, Mock
+
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        broken = Mock()
+        side_effect = RedisConnectionError("connection lost")
+        broken.setex = AsyncMock(side_effect=side_effect)
+        broken.exists = AsyncMock(side_effect=side_effect)
+        broken.ping = AsyncMock(side_effect=side_effect)
+        s = RefreshTokenStore(client=broken)
+        with pytest.raises(TokenStoreUnavailableError):
+            await s.deny_jti("jti", ttl_seconds=60)
+        with pytest.raises(TokenStoreUnavailableError):
+            await s.is_denied("jti")
+        with pytest.raises(TokenStoreUnavailableError):
+            await s.ping()
+
+    @pytest.mark.asyncio
+    async def test_url_client_ping(self, store):
+        assert await store.ping() is True
+
+
+async def _sleep(seconds: float) -> None:
+    import asyncio
+
+    await asyncio.sleep(seconds)

--- a/tests/unit/infrastructure/test_refresh_tokens_vendor_parity.py
+++ b/tests/unit/infrastructure/test_refresh_tokens_vendor_parity.py
@@ -1,0 +1,50 @@
+"""Vendor parity guard: dashboard/backend copy must match the repo-level module.
+
+The dashboard ships a vendored copy of ``src/infrastructure/refresh_tokens``
+under ``dashboard/backend/src/infrastructure/refresh_tokens`` (same pattern as
+the qa_visual module) because the Docker build context only includes
+``dashboard/backend``. These two copies WILL drift silently unless a test
+fails loudly. If a file changes on either side, re-copy the module:
+
+    cp src/infrastructure/refresh_tokens/*.py \
+       dashboard/backend/src/infrastructure/refresh_tokens/
+
+Skipped automatically when the vendored copy is absent (e.g. slim deploys that
+only run the repo-level suite).
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SOURCE_DIR = REPO_ROOT / "src" / "infrastructure" / "refresh_tokens"
+VENDOR_DIR = REPO_ROOT / "dashboard" / "backend" / "src" / "infrastructure" / "refresh_tokens"
+
+pytestmark = pytest.mark.skipif(
+    not VENDOR_DIR.is_dir(), reason="vendored refresh_tokens copy not present"
+)
+
+
+def _py_files(directory: Path) -> dict[str, str]:
+    return {p.name: p.read_text() for p in sorted(directory.glob("*.py"))}
+
+
+def test_vendored_copy_exists():
+    assert VENDOR_DIR.is_dir(), "dashboard vendored refresh_tokens module is missing"
+    assert (VENDOR_DIR / "__init__.py").is_file()
+
+
+def test_vendored_copy_matches_source_file_by_file():
+    source = _py_files(SOURCE_DIR)
+    vendored = _py_files(VENDOR_DIR)
+    assert set(source) == set(vendored), (
+        f"file sets differ: only in source={set(source) - set(vendored)}, "
+        f"only in vendored={set(vendored) - set(source)}"
+    )
+    drifted = [name for name, content in source.items() if vendored[name] != content]
+    assert not drifted, (
+        f"vendored refresh_tokens copy drifted from src/ in: {drifted}. "
+        "Re-copy with: cp src/infrastructure/refresh_tokens/*.py "
+        "dashboard/backend/src/infrastructure/refresh_tokens/"
+    )


### PR DESCRIPTION
## What was done

Refresh token rotation with reuse detection and explicit revocation for the dashboard auth service (finding F-2 Medium, OWASP API2:2023 Broken Authentication, card 3ae2e5c1):

1. **jti único por emisión**: every refresh token now carries a unique `jti` (UUID4) plus a `fam` (family) claim — fresh family at login, inherited across rotations.
2. **ROTACIÓN**: `POST /api/v1/auth/refresh` returns a NEW access+refresh pair and atomically consumes the old `jti` in Redis (`SET NX EX`, TTL = the token's remaining lifetime — the denylist self-cleans exactly when the token would have expired anyway). The SET-NX atomicity closes the concurrent-refresh race (two parallel refreshes with the same token can't both rotate).
3. **REUSE DETECTION**: replaying a consumed token → 401 + whole-family revocation (the legitimately-rotated descendant dies too) + `SECURITY:` alarm log at ERROR level. Tokens from a revoked family are always rejected.
4. **`POST /api/v1/auth/revoke`**: RFC 7009-style explicit logout — idempotent (invalid/expired tokens still return 200, no validity oracle), kills the presented token AND its family.
5. **Redis store**: new self-contained `src/infrastructure/refresh_tokens` module (DI client, config-agnostic, no hardcoded credentials — connection built from `REDIS_HOST`/`REDIS_PORT`/`REDIS_PASSWORD` env only). Vendored verbatim into `dashboard/backend/src/infrastructure/refresh_tokens` with a parity guard test (same pattern as `qa_visual`).
6. **Fail-closed**: refresh/revoke answer 503 when Redis is unreachable — the denylist can never be bypassed by an outage.
7. **Legacy migration**: pre-`jti` tokens refresh once (one-time upgrade) and expire naturally; no forced logout on deploy.
8. `tests/conftest.py`: the global redis mock now keeps `redis.exceptions` importable — this also un-breaks 10 pre-existing `test_test_cache.py` failures present in main.

## Where artifacts are

- Store: `src/infrastructure/refresh_tokens/store.py` + `__init__.py`; vendored copy at `dashboard/backend/src/infrastructure/refresh_tokens/`
- Service wiring: `dashboard/backend/services/auth_service.py` (`create_refresh_token`, `refresh_access_token`, `revoke_refresh_token`, `get_refresh_token_store`)
- Endpoint: `dashboard/backend/api/v1/auth_routes.py` (`POST /auth/revoke`)
- Tests: `tests/unit/infrastructure/test_refresh_token_store.py` (13), `tests/unit/infrastructure/test_refresh_tokens_vendor_parity.py` (2), `dashboard/backend/tests/unit/test_refresh_rotation.py` (18)
- Docs: `CHANGELOG.md`, `dashboard/CHANGELOG.md`

## How to verify

```bash
# Redis must be reachable at 127.0.0.1:6379 (tests skip otherwise)
# Repo-level (venv /tmp/pr135-venv/bin)
/tmp/pr135-venv/bin/python -m pytest tests/unit/ -q --no-cov
# -> 814 passed, 10 skipped

# Dashboard
cd dashboard/backend && /tmp/pr135-venv/bin/python -m pytest tests/unit/ -q --no-cov
# -> 79 passed, 9 skipped (asyncpg absent, pre-existing)

# Mandatory lint (both clean on src+tests)
/tmp/pr135-venv/bin/ruff check src tests && /tmp/pr135-venv/bin/isort --check-only src tests

# Vendor parity
diff -r src/infrastructure/refresh_tokens dashboard/backend/src/infrastructure/refresh_tokens
```

## Known issues

- 10 dashboard test failures exist in this suite, but ALL of them are pre-existing on `main` (verified: `git stash -u` baseline run — main fails 20, this branch fails 10; zero new failures, list is an exact subset). Related to bulk_service mocks and cache/event-loop issues, untouched by this change.
- Access tokens remain stateless/short-lived (denylist covers refresh tokens only, per card scope).
- Legacy pre-`jti` tokens cannot be server-side revoked (nothing to denylist); they age out in ≤7 days.
- `src/infrastructure/auth/` package (unrelated to this work) is broken at main (`session_store`/`APIKey` missing) — deliberately not touched.

## What's next

- Security-auditor + QA pipeline review of this PR.
- Optional follow-up: shorten refresh lifetime / add grace window on rotation if strict single-use causes UX friction with parallel clients.
- Optional follow-up: wire the SECURITY reuse alarm into alerting/metrics.
- Fix pre-existing dashboard suite failures (bulk_service, cache event-loop) as separate cards.