### PR TITLE
ci: redis service para tests de rotación refresh — fin de skips (card 3182f5fa)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -139,6 +139,17 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
+    services:
+      # Redis for refresh-token store unit tests (card 3182f5fa)
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v7 # v4.2.2

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -129,6 +129,17 @@ jobs:
   dashboard-middleware-tests:
     name: Dashboard Backend Middleware Tests
     runs-on: ubuntu-latest
+    services:
+      # Redis for refresh-token rotation unit tests (card 3182f5fa)
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v4 # v4.2.2
@@ -183,6 +194,14 @@ jobs:
             --no-cov \
             --junitxml=junit-wiring.xml
 
+      - name: Run dashboard unit tests (refresh rotation — needs redis)
+        if: steps.changed-files.outputs.run_middleware_tests == 'true'
+        run: |
+          cd dashboard/backend
+          python -m pytest tests/unit -v \
+            --no-cov \
+            --junitxml=junit-unit.xml
+
       - name: Upload middleware test results
         if: steps.changed-files.outputs.run_middleware_tests == 'true' && always()
         uses: actions/upload-artifact@v4 # v4.6.2
@@ -191,6 +210,7 @@ jobs:
           path: |
             dashboard/backend/junit-middleware.xml
             dashboard/backend/junit-wiring.xml
+            dashboard/backend/junit-unit.xml
 
   # PR size check
   pr-size-check:


### PR DESCRIPTION
## Qué
Los tests de la feature security PR #141 (refresh rotation, jti+reuse detection) se SKIPPEABAN en CI por falta de Redis. Ahora corren:

- **ci-cd.yml `unit-tests`** (3.11/3.12): services `redis:7-alpine` (mismo patrón health-check que el job integration existente) → `test_refresh_token_store.py` **15 tests** corren.
- **pr-checks.yml `dashboard-middleware-tests`**: services redis + nuevo step `Run dashboard unit tests` → `test_refresh_rotation.py` **18 tests** corren cuando `dashboard/backend/**` cambia (job condicional existente).

## Compatibilidad verificada
Ambas suites usan `redis://127.0.0.1:6379/15` (db 15, sin auth) → service en localhost:6379 cubre. `redis==5.2.0` en dashboard requirements; `redis 5.0.1` en poetry. YAML validado.

## AC
1. En el run de ESTE PR: `Unit Tests (3.11/3.12)` muestra los 15 del store **0 skipped** ✅
2. Los 18 del dashboard se ejercitan en el próximo PR que toque dashboard/backend (job condicional)
3. Redis service arranca en ~5s — no rompe tiempos

Card **3182f5fa**. Advisory reviewer gate 2 del PR #141.