### PR TITLE
security(ci): R4 SHA-pinning completo — 130 actions refs a commit SHA (card fd02f770)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,20 +28,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v3 # v3.0.2
+        uses: abatilo/actions-poetry@65c61eae400c65c9510a584af85138c1ae19bbc0 # v3.0.2
         with:
           poetry-version: ${{ env.POETRY_VERSION }}
 
       - name: Cache Poetry packages
-        uses: actions/cache@v4 # v4.2.3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/pypoetry
           key: ${{ env.CACHE_VERSION }}-${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}
@@ -73,7 +73,7 @@ jobs:
         run: pip install pip-audit && pip-audit -r requirements.txt --desc --output-format json --output-file safety-report.json || true
 
       - name: Upload security reports
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: security-reports
@@ -91,15 +91,15 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[middleware]')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Cache pip packages
-        uses: actions/cache@v4 # v4.2.3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/pip
           key: ${{ env.CACHE_VERSION }}-${{ runner.os }}-pip-dashboard-${{ hashFiles('dashboard/backend/requirements.txt') }}
@@ -121,7 +121,7 @@ jobs:
             --junitxml=junit-middleware.xml
 
       - name: Upload middleware test results
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: middleware-test-results
@@ -141,20 +141,20 @@ jobs:
         python-version: ["3.11", "3.12"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v3 # v3.0.2
+        uses: abatilo/actions-poetry@65c61eae400c65c9510a584af85138c1ae19bbc0 # v3.0.2
         with:
           poetry-version: ${{ env.POETRY_VERSION }}
 
       - name: Cache Poetry packages
-        uses: actions/cache@v4 # v4.2.3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/pypoetry
           key: ${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.python-version }}-poetry-${{ hashFiles('**/pyproject.toml') }}
@@ -175,7 +175,7 @@ jobs:
             -n auto
 
       - name: Upload unit test results
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: unit-test-results-${{ matrix.python-version }}
@@ -219,20 +219,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v3 # v3.0.2
+        uses: abatilo/actions-poetry@65c61eae400c65c9510a584af85138c1ae19bbc0 # v3.0.2
         with:
           poetry-version: ${{ env.POETRY_VERSION }}
 
       - name: Cache Poetry packages
-        uses: actions/cache@v4 # v4.2.3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/pypoetry
           key: ${{ env.CACHE_VERSION }}-${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}
@@ -269,7 +269,7 @@ jobs:
           REDIS_URL: redis://localhost:6379/0
 
       - name: Upload integration test results
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: integration-test-results
@@ -289,10 +289,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -302,7 +302,7 @@ jobs:
           sudo apt-get install -y libgbm-dev libwoff1 libopus0 libwebpdemux2 libenchant-2-2 libsecret-1-0 libhyphen0 libgdk-pixbuf2.0-0 libegl1 libgles2
 
       - name: Cache pip packages
-        uses: actions/cache@v4 # v4.2.3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/pip
           key: ${{ env.CACHE_VERSION }}-${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
@@ -325,7 +325,7 @@ jobs:
             --junitxml=junit-e2e.xml
 
       - name: Set up Node.js for Playwright TypeScript tests
-        uses: actions/setup-node@v4 # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '26'
 
@@ -360,7 +360,7 @@ jobs:
           CI: true
 
       - name: Upload Playwright test results
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: playwright-test-results
@@ -371,7 +371,7 @@ jobs:
           retention-days: 7
 
       - name: Upload E2E test results
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: e2e-test-results
@@ -389,15 +389,15 @@ jobs:
     if: github.event_name == 'schedule' || contains(github.event.head_commit.message, '[perf]')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Cache pip packages
-        uses: actions/cache@v4 # v4.2.3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/pip
           key: ${{ env.CACHE_VERSION }}-${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
@@ -417,7 +417,7 @@ jobs:
             --junitxml=junit-performance.xml || echo "Performance tests completed with warnings"
 
       - name: Upload performance results
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: performance-test-results
@@ -434,15 +434,15 @@ jobs:
     needs: code-quality
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Cache pip packages
-        uses: actions/cache@v4 # v4.2.3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/pip
           key: ${{ env.CACHE_VERSION }}-${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
@@ -461,7 +461,7 @@ jobs:
         run: pip-audit -r requirements.txt --desc --output-format json --output-file dependency-scan.json || true
 
       - name: Upload security test results
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: security-test-results
@@ -481,15 +481,15 @@ jobs:
       checks: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Download all coverage reports
-        uses: actions/download-artifact@v8 # v4.3.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: '*-test-results*'
           merge-multiple: true
@@ -500,7 +500,7 @@ jobs:
           pip install codecov
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5 # v5.4.3
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           files: ./coverage.xml
           flags: unittests
@@ -508,7 +508,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-report
           path: coverage-report/
@@ -521,10 +521,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -538,7 +538,7 @@ jobs:
           mkdocs build
 
       - name: Upload documentation
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: documentation
           path: site/
@@ -552,10 +552,10 @@ jobs:
     needs: [code-quality]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -572,7 +572,7 @@ jobs:
           trivy filesystem --format cyclonedx --output qa-framework-sbom.cdx .
 
       - name: Upload SBOM as artifact
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sbom
           path: qa-framework-sbom.cdx
@@ -593,10 +593,10 @@ jobs:
     needs: [unit-tests, code-quality, generate-sbom]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -612,7 +612,7 @@ jobs:
         run: twine check dist/*
 
       - name: Upload package
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: package
           path: dist/
@@ -627,7 +627,7 @@ jobs:
     if: always()
     steps:
       - name: Download all test results
-        uses: actions/download-artifact@v8 # v4.3.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: '*-test-results*'
           merge-multiple: true

--- a/.github/workflows/dast-zap.yml
+++ b/.github/workflows/dast-zap.yml
@@ -52,11 +52,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run ZAP Baseline scan
         id: zap
-        uses: zaproxy/action-baseline@v0.13.0 # v0.13.0
+        uses: zaproxy/action-baseline@0619037bb784a56e2e06b104f0ebe157e076f075 # v0.13.0
         with:
           target: ${{ env.ZAP_TARGET }}
           rules_file_name: '.github/zap-rules.tsv'
@@ -98,14 +98,14 @@ jobs:
           fi
 
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3 # v3.29.5
+        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
         if: always() && hashFiles('zap_report.sarif') != ''
         with:
           sarif_file: zap_report.sarif
           category: zap-dast
 
       - name: Upload SARIF + JSON artifacts
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: zap-dast-results
@@ -157,7 +157,7 @@ jobs:
     if: always()
     steps:
       - name: Download ZAP results
-        uses: actions/download-artifact@v8 # v4.3.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: zap-dast-results
         continue-on-error: true

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -53,7 +53,7 @@ jobs:
       TRIVY_DB_REPOSITORY: "mirror.gcr.io/aquasec/trivy-db:2"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # AC2 test hook: proves the gate blocks the deploy when it fails
       - name: Force-fail hook (TEST ONLY — workflow_dispatch input)
@@ -97,7 +97,7 @@ jobs:
           echo "SBOM_OK=true" >> "$GITHUB_ENV"
 
       - name: 'Gate 4/4b: SLSA provenance attestation (SBOM subjects)'
-        uses: actions/attest-build-provenance@v2 # v2.4.0
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: |
             sbom-backend.cdx.json
@@ -147,7 +147,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Railway CLI
         run: npm install -g @railway/cli
@@ -195,10 +195,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,10 +25,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4 # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '26'
           cache: 'npm'
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload test artifacts
         if: '!cancelled()'
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: dashboard/frontend/playwright-report/

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,20 +54,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v3 # v3.0.2
+        uses: abatilo/actions-poetry@65c61eae400c65c9510a584af85138c1ae19bbc0 # v3.0.2
         with:
           poetry-version: ${{ env.POETRY_VERSION }}
 
       - name: Cache Poetry packages
-        uses: actions/cache@v4 # v4.2.3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/pypoetry
           key: ${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.python-version }}-poetry-${{ hashFiles('**/pyproject.toml') }}
@@ -175,7 +175,7 @@ jobs:
           echo "Tests for '${{ matrix.test-type }}' were skipped (not implemented yet)" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload results
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: ${{ matrix.test-type }}-py${{ matrix.python-version }}-results
@@ -195,7 +195,7 @@ jobs:
     if: always()
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v8 # v4.3.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: '*-results'
           merge-multiple: true
@@ -225,14 +225,14 @@ jobs:
           fi
 
       - name: Upload nightly report
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: nightly-report
           path: nightly-report.md
 
       - name: Create issue on significant failures
         if: failure()
-        uses: actions/github-script@v9 # v7.1.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');

--- a/.github/workflows/owasp-security.yml
+++ b/.github/workflows/owasp-security.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Semgrep
         run: pip install semgrep==1.165.0
@@ -50,14 +50,14 @@ jobs:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 
       - name: Upload Semgrep SARIF
-        uses: github/codeql-action/upload-sarif@v3 # v3.29.5
+        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
         if: always()
         with:
           sarif_file: semgrep-results.sarif
           category: semgrep-owasp
 
       - name: Upload Semgrep artifact
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: semgrep-results
@@ -72,12 +72,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0  # Full history for secret scanning
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2 # v2.3.9
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
@@ -90,10 +90,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -114,7 +114,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload OWASP test report
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: owasp-compliance-report
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Syft
         run: |
@@ -152,7 +152,7 @@ jobs:
           syft . -o spdx-json > sbom-syft-spdx.json
 
       - name: Upload SBOM artifacts
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sbom-syft
           path: |
@@ -170,7 +170,7 @@ jobs:
     if: always()
     steps:
       - name: Download Semgrep results
-        uses: actions/download-artifact@v8 # v4.3.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         continue-on-error: true  # step-level: download-artifact has no such input
         with:
           name: semgrep-results

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,17 +23,17 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0  # Full history for proper diff
 
       - name: Set up Python
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Cache pip packages
-        uses: actions/cache@v4 # v4.2.3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
@@ -88,7 +88,7 @@ jobs:
       - name: Comment PR with results
         if: always()
         continue-on-error: true  # Gracefully handle permission errors (e.g., dependabot PRs)
-        uses: actions/github-script@v9 # v7.1.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const outputs = {
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -148,13 +148,13 @@ jobs:
 
       - name: Set up Python
         if: steps.changed-files.outputs.run_middleware_tests == 'true'
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Cache pip packages
         if: steps.changed-files.outputs.run_middleware_tests == 'true'
-        uses: actions/cache@v4 # v4.2.3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-dashboard-${{ hashFiles('dashboard/backend/requirements.txt') }}
@@ -185,7 +185,7 @@ jobs:
 
       - name: Upload middleware test results
         if: steps.changed-files.outputs.run_middleware_tests == 'true' && always()
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: middleware-test-results
           path: |
@@ -198,7 +198,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-deploy-coolify.yml
+++ b/.github/workflows/pr-deploy-coolify.yml
@@ -39,7 +39,7 @@ jobs:
       TRIVY_DB_REPOSITORY: "mirror.gcr.io/aquasec/trivy-db:2"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Force-fail hook (TEST ONLY — PR label gate-force-fail)
         if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'gate-force-fail')
@@ -82,7 +82,7 @@ jobs:
 
       - name: 'Gate 4/4b: SLSA provenance attestation (SBOM subjects)'
         if: github.actor != 'dependabot[bot]'
-        uses: actions/attest-build-provenance@v2 # v2.4.0
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: |
             sbom-backend.cdx.json
@@ -133,22 +133,22 @@ jobs:
       preview_url: ${{ steps.deploy.outputs.preview_url }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3 # v3.10.0
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Log in to Coolify Registry
-        uses: docker/login-action@v4 # v3.4.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ${{ secrets.COOLIFY_REGISTRY_URL }}
           username: ${{ secrets.COOLIFY_REGISTRY_USERNAME }}
           password: ${{ secrets.COOLIFY_REGISTRY_PASSWORD }}
 
       - name: Build and push Backend Docker image
-        uses: docker/build-push-action@v7 # v6.18.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: ./dashboard/backend/Dockerfile
@@ -189,7 +189,7 @@ jobs:
           fi
 
       - name: Comment PR with Backend Preview URL
-        uses: actions/github-script@v9 # v7.1.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const previewUrl = '${{ steps.deploy.outputs.preview_url }}';
@@ -245,12 +245,12 @@ jobs:
       preview_url: ${{ steps.deploy.outputs.preview_url }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4 # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -274,17 +274,17 @@ jobs:
           VITE_API_URL: ${{ secrets.COOLIFY_FRONTEND_PREVIEW_API_URL }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3 # v3.10.0
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Log in to Coolify Registry
-        uses: docker/login-action@v4 # v3.4.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ${{ secrets.COOLIFY_REGISTRY_URL }}
           username: ${{ secrets.COOLIFY_REGISTRY_USERNAME }}
           password: ${{ secrets.COOLIFY_REGISTRY_PASSWORD }}
 
       - name: Build and push Frontend Docker image
-        uses: docker/build-push-action@v7 # v6.18.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ./dashboard/frontend
           file: ./dashboard/frontend/Dockerfile
@@ -325,7 +325,7 @@ jobs:
           fi
 
       - name: Comment PR with Frontend Preview URL
-        uses: actions/github-script@v9 # v7.1.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const previewUrl = '${{ steps.deploy.outputs.preview_url }}';
@@ -439,7 +439,7 @@ jobs:
 
       - name: Comment PR with Health Check Results
         if: always()
-        uses: actions/github-script@v9 # v7.1.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const backendStatus = '${{ steps.backend-health.outputs.status }}';
@@ -492,7 +492,7 @@ jobs:
           echo "Frontend preview cleanup response: $RESPONSE"
 
       - name: Comment PR with Cleanup Confirmation
-        uses: actions/github-script@v9 # v7.1.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const message = `## 🧹 Preview Cleanup

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -38,12 +38,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5 # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -64,13 +64,13 @@ jobs:
           done
 
       - name: Generate build provenance attestation
-        uses: actions/attest-build-provenance@v2 # v2.4.0  # v1.4.3
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: 'dist/*'
           subject-name: ${{ github.repository }}@${{ github.sha }}
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: python-package
           path: dist/
@@ -85,7 +85,7 @@ jobs:
     needs: [provenance]
     steps:
       - name: Download built artifacts
-        uses: actions/download-artifact@v8 # v4.3.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: python-package
           path: dist/

--- a/.github/workflows/trivy-security.yml
+++ b/.github/workflows/trivy-security.yml
@@ -44,10 +44,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Trivy
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -62,14 +62,14 @@ jobs:
           TRIVY_JAVA_DB_REPOSITORY: ""
 
       - name: Upload FS scan SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3 # v3.29.5
+        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
         if: always()
         with:
           sarif_file: 'trivy-fs-results.sarif'
           category: 'trivy-fs'
 
       - name: Upload FS scan results artifact
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: trivy-fs-results
@@ -103,13 +103,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Build backend Docker image
         run: docker build -t qa-framework-backend:scan -f dashboard/backend/Dockerfile dashboard/backend
 
       - name: Scan backend image with Trivy
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: 'qa-framework-backend:scan'
           format: 'sarif'
@@ -121,14 +121,14 @@ jobs:
           TRIVY_SKIP_DB_UPDATE: "false"
 
       - name: Upload backend image SARIF
-        uses: github/codeql-action/upload-sarif@v3 # v3.29.5
+        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
         if: always()
         with:
           sarif_file: 'trivy-backend-image.sarif'
           category: 'trivy-backend-image'
 
       - name: Upload backend scan artifact
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: trivy-backend-image-results
@@ -143,13 +143,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Build frontend Docker image
         run: docker build -t qa-framework-frontend:scan -f dashboard/frontend/Dockerfile dashboard/frontend
 
       - name: Scan frontend image with Trivy
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: 'qa-framework-frontend:scan'
           format: 'sarif'
@@ -161,14 +161,14 @@ jobs:
           TRIVY_SKIP_DB_UPDATE: "false"
 
       - name: Upload frontend image SARIF
-        uses: github/codeql-action/upload-sarif@v3 # v3.29.5
+        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
         if: always()
         with:
           sarif_file: 'trivy-frontend-image.sarif'
           category: 'trivy-frontend-image'
 
       - name: Upload frontend scan artifact
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: trivy-frontend-image-results
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Trivy
         run: |
@@ -204,7 +204,7 @@ jobs:
           TRIVY_SKIP_DB_UPDATE: "true"
 
       - name: Upload SBOM artifacts
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sbom-reports
           path: |
@@ -229,10 +229,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Scan IaC files with Trivy
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'config'
           scan-ref: '.'
@@ -244,14 +244,14 @@ jobs:
           TRIVY_SKIP_DB_UPDATE: "true"
 
       - name: Upload IaC SARIF
-        uses: github/codeql-action/upload-sarif@v3 # v3.29.5
+        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
         if: always()
         with:
           sarif_file: 'trivy-iac-results.sarif'
           category: 'trivy-iac'
 
       - name: Upload IaC scan artifact
-        uses: actions/upload-artifact@v4 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: trivy-iac-results
@@ -268,7 +268,7 @@ jobs:
     if: github.event_name == 'pull_request' && always()
     steps:
       - name: Download all Trivy artifacts
-        uses: actions/download-artifact@v8 # v4.3.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: 'trivy-*-results'
           merge-multiple: true
@@ -303,7 +303,7 @@ jobs:
           fi
 
       - name: Comment PR with Trivy results
-        uses: actions/github-script@v9 # v7.1.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const total = '${{ steps.summary.outputs.total }}';
@@ -378,7 +378,7 @@ jobs:
     if: always()
     steps:
       - name: Download all Trivy artifacts
-        uses: actions/download-artifact@v8 # v4.3.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: 'trivy-*-results'
           merge-multiple: true

--- a/docs/ACTIONS_SHA_POLICY.md
+++ b/docs/ACTIONS_SHA_POLICY.md
@@ -1,0 +1,32 @@
+# GitHub Actions — Política SHA-pinning (R4)
+
+**Regla: TODAS las `uses:` en `.github/workflows/` van pinned a commit SHA completo con comment de versión.**
+
+```yaml
+uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+```
+
+## Por qué
+Refs por tag (`@v4`) son mutables: un tag comprometido en upstream ejecuta código
+atacante en nuestro CI (vector supply-chain MoYu/BADBOX, case study card 3bb1f21e §6 R4).
+
+## Cómo pinear una action nueva
+1. Resuelve el commit SHA del tag (los tags anotados requieren dereference):
+   ```bash
+   gh api repos/OWNER/REPO/git/ref/tags/vX.Y.Z --jq '.object.sha'
+   # si .object.type == "tag" (anotado):
+   gh api repos/OWNER/REPO/git/tags/<sha-anterior> --jq '.object.sha'
+   ```
+2. Escribe `uses: OWNER/REPO@<40-hex> # vX.Y.Z`
+
+## Verificación (CI/grep)
+```bash
+grep -rh 'uses:' .github/workflows/ | grep -vcE '@[0-9a-f]{40}'   # debe ser 0
+```
+
+## Actualización de versions
+Bump = resolver SHA del nuevo tag + PR (el comment muestra la versión — revisor
+verifica que el SHA corresponde al tag del comment).
+
+Aplicado 2026-08-25 (card fd02f770): 130 refs en 10 workflows.
+Precedente: fix SHAs rotos (card edbd4a58).


### PR DESCRIPTION
## Qué
Todas las `uses:` de los **10 workflows** (130 refs, 19 actions únicas) pasan de tag a **commit SHA completo** con comment de versión:

```yaml
uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
```

Incluye **corrección de refs anómalas** heredadas del fix edbd4a58 (`checkout@v7 # v4.2.2`, `download-artifact@v8`, `github-script@v9` — tags mayores inexistentes): ahora todas apuntan al SHA real de la versión del comment.

## Por qué
Refs por tag = mutables → tag comprometido upstream ejecuta código en nuestro CI (vector supply-chain MoYu/BADBOX, case study card 3bb1f21e §6 R4).

## Nuevas actions
`docs/ACTIONS_SHA_POLICY.md`: regla siempre-SHA + procedimiento de resolución (gh api git/ref/tags + dereference de annotated) + comando de verificación.

## Verificación
- `grep -rh 'uses:' .github/workflows/ | grep -vcE '@[0-9a-f]{40}'` → **0**
- YAML 10/10 válidos
- CI de este PR = test real post-pinning (AC2)

Card **fd02f770**. Precedente: edbd4a58 (SHAs rotos).