### PR TITLE
fix(security): erradicar defaults de secrets + docs condicionales en production (card 2972521c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Erradicated committed secret defaults + conditional API docs
+  (card 2972521c, incident 112853a6, CWE-798 / F1-residual + F3)**:
+  - `docker-compose.unified.yml`: `SECRET_KEY` is now a required compose
+    variable (`${SECRET_KEY:?...}`) — no committed fallback; `docker compose`
+    fails fast when unset. Provide it via env or a local overrides file
+    (e.g. `docker-compose.staging-overrides.yml`, untracked).
+  - `dashboard/backend/config/environment_config.py`: `SECRET_KEY` and
+    `JWT_SECRET_KEY` are required fields (min 32 chars) — no defaults.
+  - `dashboard/backend/config.py`: the development-only JWT fallback is now
+    an ephemeral per-process random key (`secrets.token_urlsafe(48)`) instead
+    of a committed constant; production still crashes at boot without an
+    explicit secret (`_validate_production_config`, covered by tests).
+  - `dashboard/backend/main.py`: OpenAPI/Swagger/Redoc endpoints
+    (`/api/v1/docs`, `/api/v1/openapi.json`, `/api/v1/redoc`) are disabled
+    when `settings.is_production` (finding F3, previously 200 on staging).
+  - Guard tests in `dashboard/backend/tests/unit/` enforce the acceptance
+    criteria (no committed dev-secret literals in tracked files,
+    fail-closed production boot, docs mounted in dev / absent in
+    production).
+
 - **Refresh token rotation + reuse detection (card 3ae2e5c1, finding F-2,
   OWASP API2)**: new self-contained module
   `src/infrastructure/refresh_tokens` (vendored verbatim into

--- a/README.md
+++ b/README.md
@@ -246,13 +246,17 @@ pip install -r requirements.txt
 ENVIRONMENT=development .venv/bin/python -m uvicorn main:app --host 0.0.0.0 --port 8000
 
 # Backend runs at: http://localhost:8000
-# API docs at: http://localhost:8000/api/v1/docs
+# API docs at: http://localhost:8000/api/v1/docs (disabled when ENVIRONMENT=production)
 ```
 
 **Environment variables (all optional in development):**
 - `DATABASE_URL` — PostgreSQL URL. If unset, falls back to SQLite (`./qafw.db`)
 - `REDIS_URL` — Redis URL. If unset, defaults to `redis://localhost:6379/0`
-- `JWT_SECRET_KEY` — JWT signing key. If unset, a dev fallback is used
+- `JWT_SECRET_KEY` — JWT signing key. If unset in development, an ephemeral
+  random per-process key is generated (sessions do not survive restarts).
+  **Required in production**: the backend refuses to boot without it
+- `SECRET_KEY` — application signing key, required by `docker-compose.unified.yml`
+  (no committed default; provide it via env or a local overrides file)
 - `ENVIRONMENT` — `development` or `production` (default: `development`)
 
 ### 🧪 Run Dashboard Backend Tests

--- a/dashboard/backend/config.py
+++ b/dashboard/backend/config.py
@@ -1,4 +1,5 @@
 import os
+import secrets
 import warnings
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import Optional
@@ -37,12 +38,14 @@ class Settings(BaseSettings):
     # Stripe - REQUIRED for billing
     STRIPE_API_KEY: Optional[str] = os.getenv("STRIPE_API_KEY")
     STRIPE_WEBHOOK_SECRET: Optional[str] = os.getenv("STRIPE_WEBHOOK_SECRET")
-    
+
     # Stripe Price IDs (LIVE)
     STRIPE_PRICE_FREE: str = os.getenv("STRIPE_PRICE_FREE", "price_1TEvdOI1MtlKoNQt5aepkf0d")
     STRIPE_PRICE_PRO: str = os.getenv("STRIPE_PRICE_PRO", "price_1TEvdOI1MtlKoNQtonZGU7S7")
-    STRIPE_PRICE_ENTERPRISE: str = os.getenv("STRIPE_PRICE_ENTERPRISE", "price_1TEvdPI1MtlKoNQtdRE8CP5m")
-    
+    STRIPE_PRICE_ENTERPRISE: str = os.getenv(
+        "STRIPE_PRICE_ENTERPRISE", "price_1TEvdPI1MtlKoNQtdRE8CP5m"
+    )
+
     # Stripe Product IDs (LIVE)
     STRIPE_PRODUCT_FREE: str = os.getenv("STRIPE_PRODUCT_FREE", "prod_UDMMUYX064DjtC")
     STRIPE_PRODUCT_PRO: str = os.getenv("STRIPE_PRODUCT_PRO", "prod_UDMMlPYySnUofh")
@@ -50,23 +53,23 @@ class Settings(BaseSettings):
 
     # Feature Flags
     ENABLE_BILLING: bool = os.getenv("ENABLE_BILLING", "false").lower() == "true"
-    
+
     # Browser-Use AI-Powered Test Automation
     BROWSER_USE_LLM_PROVIDER: str = os.getenv("BROWSER_USE_LLM_PROVIDER", "groq")
     BROWSER_USE_MODEL: str = os.getenv("BROWSER_USE_MODEL", "llama-3.3-70b-versatile")
-    
+
     # Browser-Use AI-Powered Test Automation
     BROWSER_USE_LLM_PROVIDER: str = os.getenv("BROWSER_USE_LLM_PROVIDER", "groq")
     GROQ_API_KEY: Optional[str] = os.getenv("GROQ_API_KEY")
     BROWSER_USE_MODEL: str = os.getenv("BROWSER_USE_MODEL", "llama-3.3-70b-versatile")
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
-    
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._validate_production_config()
         self._warn_insecure_defaults()
-    
+
     def _validate_production_config(self):
         """Validate that all required variables are set in production."""
         if self.ENVIRONMENT == "production":
@@ -74,56 +77,66 @@ class Settings(BaseSettings):
                 "DATABASE_URL": self.database_url,
                 "JWT_SECRET_KEY": self.secret_key,
             }
-            
+
             if self.ENABLE_BILLING:
-                required_vars.update({
-                    "STRIPE_API_KEY": self.STRIPE_API_KEY,
-                    "STRIPE_WEBHOOK_SECRET": self.STRIPE_WEBHOOK_SECRET,
-                })
-            
+                required_vars.update(
+                    {
+                        "STRIPE_API_KEY": self.STRIPE_API_KEY,
+                        "STRIPE_WEBHOOK_SECRET": self.STRIPE_WEBHOOK_SECRET,
+                    }
+                )
+
             missing = [k for k, v in required_vars.items() if not v]
             if missing:
                 raise ValueError(
                     f"Missing required environment variables in production: {', '.join(missing)}. "
                     "Set these variables before starting the application."
                 )
-    
+
     def _warn_insecure_defaults(self):
         """Warn when using insecure default values."""
         if self.ENVIRONMENT != "production":
             warning_messages = []
-            
+
             if not self.database_url:
-                warning_messages.append("DATABASE_URL not set - using in-memory SQLite (not suitable for production)")
-            
+                warning_messages.append(
+                    "DATABASE_URL not set - using in-memory SQLite (not suitable for production)"
+                )
+
             if not self.secret_key:
-                # Generate a development-only secret key for JWT
-                secret_key_str = "dev-secret-key-not-for-production-use"
-                object.__setattr__(self, 'secret_key', secret_key_str)
-                warning_messages.append("JWT_SECRET_KEY not set - using dev fallback (sessions will not persist across restarts)")
-            
+                # Dev-only fallback: a per-process random secret. Nothing is
+                # committed, so tokens signed in dev are unguessable but do
+                # not survive a restart. Production never reaches this path
+                # (_validate_production_config crashes first).
+                object.__setattr__(self, "secret_key", secrets.token_urlsafe(48))
+                warning_messages.append(
+                    "JWT_SECRET_KEY not set - using ephemeral dev fallback (sessions will not persist across restarts)"
+                )
+
             if self.ENABLE_BILLING and not self.STRIPE_API_KEY:
-                warning_messages.append("Billing enabled but STRIPE_API_KEY not set - billing will fail")
-            
+                warning_messages.append(
+                    "Billing enabled but STRIPE_API_KEY not set - billing will fail"
+                )
+
             for warning in warning_messages:
                 warnings.warn(warning, UserWarning)
-    
+
     @property
     def is_production(self) -> bool:
         """Check if running in production environment."""
         return self.ENVIRONMENT == "production"
-    
+
     @property
     def is_development(self) -> bool:
         """Check if running in development environment."""
         return self.ENVIRONMENT == "development"
-    
+
     @property
     def async_database_url(self) -> str:
         """Get database URL formatted for async drivers (asyncpg)."""
         if not self.database_url:
             return "sqlite+aiosqlite:///./qafw.db"
-        
+
         # Convert postgresql:// to postgresql+asyncpg:// for async support
         url = self.database_url
         if url.startswith("postgresql://"):

--- a/dashboard/backend/config/environment_config.py
+++ b/dashboard/backend/config/environment_config.py
@@ -12,6 +12,7 @@ from pydantic import BaseSettings, Field, validator
 
 class Environment(str, Enum):
     """Supported environments."""
+
     DEVELOPMENT = "development"
     STAGING = "staging"
     PRODUCTION = "production"
@@ -21,86 +22,87 @@ class Environment(str, Enum):
 class EnvironmentConfig(BaseSettings):
     """
     Multi-environment configuration with validation.
-    
+
     Configuration hierarchy (highest to lowest priority):
     1. Environment variables
     2. Environment-specific .env file
     3. Default .env file
     4. Hardcoded defaults
     """
-    
+
     # Environment
     ENVIRONMENT: Environment = Field(
-        default=Environment.DEVELOPMENT,
-        description="Current environment"
+        default=Environment.DEVELOPMENT, description="Current environment"
     )
-    
+
     # Application
     APP_NAME: str = Field(default="QA-Framework", description="Application name")
     APP_VERSION: str = Field(default="1.0.0", description="Application version")
     DEBUG: bool = Field(default=False, description="Debug mode")
-    
-    # Security
+
+    # Security — REQUIRED, no committed fallback (incident 112853a6, CWE-798).
+    # Instantiation fails unless the value comes from the environment/.env.
     SECRET_KEY: str = Field(
-        default="dev-secret-key-change-in-production",
-        description="Secret key for signing"
+        ...,
+        description="Secret key for signing (required: env or .env file only)",
+        min_length=32,
     )
     JWT_SECRET_KEY: str = Field(
-        default="dev-jwt-secret-change-in-production",
-        description="JWT signing key"
+        ...,
+        description="JWT signing key (required: env or .env file only)",
+        min_length=32,
     )
     JWT_ALGORITHM: str = Field(default="HS256", description="JWT algorithm")
     JWT_EXPIRE_MINUTES: int = Field(default=30, description="JWT expiration in minutes")
-    
+
     # Database
     DATABASE_URL: str = Field(
         default="postgresql+asyncpg://localhost:5432/qa_framework_dev",
-        description="Database connection URL"
+        description="Database connection URL",
     )
     DATABASE_POOL_SIZE: int = Field(default=5, description="Database pool size")
     DATABASE_POOL_MAX_OVERFLOW: int = Field(default=10, description="Database max overflow")
-    
+
     # Redis
     REDIS_HOST: str = Field(default="localhost", description="Redis host")
     REDIS_PORT: int = Field(default=6379, description="Redis port")
     REDIS_DB: int = Field(default=0, description="Redis database")
     REDIS_PASSWORD: Optional[str] = Field(default=None, description="Redis password")
-    
+
     # Logging
     LOG_LEVEL: str = Field(default="INFO", description="Logging level")
     LOG_FORMAT: str = Field(default="json", description="Logging format (json|text)")
     LOG_FILE: Optional[str] = Field(default=None, description="Log file path")
-    
+
     # API
     API_PREFIX: str = Field(default="/api/v1", description="API prefix")
     API_DOCS_ENABLED: bool = Field(default=True, description="Enable API docs")
     CORS_ORIGINS: list = Field(
-        default=["http://localhost:3000"],
-        description="CORS allowed origins"
+        default=["http://localhost:3000"], description="CORS allowed origins"
     )
-    
+
     # Rate Limiting
     RATE_LIMIT_ENABLED: bool = Field(default=True, description="Enable rate limiting")
     RATE_LIMIT_DEFAULT: int = Field(default=100, description="Default rate limit")
-    
+
     # Cache
     CACHE_ENABLED: bool = Field(default=True, description="Enable caching")
     CACHE_TTL: int = Field(default=300, description="Default cache TTL in seconds")
-    
+
     # Feature Flags
     FEATURE_NEW_DASHBOARD: bool = Field(default=False, description="Enable new dashboard")
     FEATURE_ADVANCED_REPORTING: bool = Field(default=False, description="Enable advanced reporting")
     FEATURE_AI_INSIGHTS: bool = Field(default=False, description="Enable AI insights")
-    
+
     # External Services
     SENTRY_DSN: Optional[str] = Field(default=None, description="Sentry DSN")
     PROMETHEUS_ENABLED: bool = Field(default=False, description="Enable Prometheus metrics")
-    
+
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"
         case_sensitive = True
-    
+
     @validator("LOG_LEVEL")
     def validate_log_level(cls, v):
         """Validate log level."""
@@ -108,78 +110,78 @@ class EnvironmentConfig(BaseSettings):
         if v.upper() not in valid_levels:
             raise ValueError(f"Invalid log level: {v}. Must be one of {valid_levels}")
         return v.upper()
-    
+
     @validator("CORS_ORIGINS", pre=True)
     def parse_cors_origins(cls, v):
         """Parse CORS origins from string or list."""
         if isinstance(v, str):
             return [origin.strip() for origin in v.split(",")]
         return v
-    
+
     def is_development(self) -> bool:
         """Check if running in development environment."""
         return self.ENVIRONMENT == Environment.DEVELOPMENT
-    
+
     def is_staging(self) -> bool:
         """Check if running in staging environment."""
         return self.ENVIRONMENT == Environment.STAGING
-    
+
     def is_production(self) -> bool:
         """Check if running in production environment."""
         return self.ENVIRONMENT == Environment.PRODUCTION
-    
+
     def is_testing(self) -> bool:
         """Check if running in testing environment."""
         return self.ENVIRONMENT == Environment.TESTING
-    
+
     def get_database_config(self) -> Dict[str, Any]:
         """Get database configuration."""
         return {
             "url": self.DATABASE_URL,
             "pool_size": self.DATABASE_POOL_SIZE,
             "max_overflow": self.DATABASE_POOL_MAX_OVERFLOW,
-            "echo": self.DEBUG  # Enable SQL logging in debug mode
+            "echo": self.DEBUG,  # Enable SQL logging in debug mode
         }
-    
+
     def get_redis_config(self) -> Dict[str, Any]:
         """Get Redis configuration."""
         config = {
             "host": self.REDIS_HOST,
             "port": self.REDIS_PORT,
             "db": self.REDIS_DB,
-            "decode_responses": True
+            "decode_responses": True,
         }
         if self.REDIS_PASSWORD:
             config["password"] = self.REDIS_PASSWORD
         return config
-    
+
     def get_feature_flags(self) -> Dict[str, bool]:
         """Get all feature flags."""
         return {
             "new_dashboard": self.FEATURE_NEW_DASHBOARD,
             "advanced_reporting": self.FEATURE_ADVANCED_REPORTING,
-            "ai_insights": self.FEATURE_AI_INSIGHTS
+            "ai_insights": self.FEATURE_AI_INSIGHTS,
         }
-    
+
     def validate_production_security(self) -> list:
         """
         Validate security settings for production.
-        
+
         Returns:
             List of security warnings
         """
         warnings = []
-        
+
         if self.is_production():
             if self.DEBUG:
                 warnings.append("DEBUG mode is enabled in production!")
-            
-            if "dev-secret" in self.SECRET_KEY or self.SECRET_KEY == "dev-secret-key-change-in-production":
-                warnings.append("Default SECRET_KEY in production!")
-            
-            if "dev-jwt" in self.JWT_SECRET_KEY or self.JWT_SECRET_KEY == "dev-jwt-secret-change-in-production":
-                warnings.append("Default JWT_SECRET_KEY in production!")
-        
+
+            if "dev-" in self.SECRET_KEY:
+                warnings.append("Development-looking SECRET_KEY in production!")
+
+            if "dev-" in self.JWT_SECRET_KEY:
+                warnings.append("Development-looking JWT_SECRET_KEY in production!")
+
         return warnings
 
 
@@ -187,10 +189,10 @@ class EnvironmentConfig(BaseSettings):
 def load_environment_config(env: Optional[Environment] = None) -> EnvironmentConfig:
     """
     Load environment-specific configuration.
-    
+
     Args:
         env: Environment to load (auto-detected if None)
-        
+
     Returns:
         EnvironmentConfig instance
     """
@@ -201,10 +203,10 @@ def load_environment_config(env: Optional[Environment] = None) -> EnvironmentCon
             env = Environment(env_str)
         except ValueError:
             env = Environment.DEVELOPMENT
-    
+
     # Set environment variable for config loading
     os.environ["ENVIRONMENT"] = env.value
-    
+
     # Load environment-specific .env file
     env_file = Path(f".env.{env.value}")
     if env_file.exists():
@@ -212,16 +214,17 @@ def load_environment_config(env: Optional[Environment] = None) -> EnvironmentCon
     else:
         # Fall back to default .env
         config = EnvironmentConfig()
-    
+
     # Validate production security
     if env == Environment.PRODUCTION:
         warnings = config.validate_production_security()
         if warnings:
             import logging
+
             logger = logging.getLogger(__name__)
             for warning in warnings:
                 logger.warning(f"SECURITY WARNING: {warning}")
-    
+
     return config
 
 

--- a/dashboard/backend/main.py
+++ b/dashboard/backend/main.py
@@ -25,13 +25,16 @@ environment = os.getenv("ENVIRONMENT", "development")
 configure_logging(log_level=log_level, environment=environment)
 logger = get_logger(__name__)
 
+# API docs (OpenAPI/Swagger/Redoc) must not be exposed in production
+# (finding F3 of incident 112853a6): FastAPI disables the endpoints when
+# the URLs are None.
 app = FastAPI(
     title="QA-Framework Dashboard API",
     description="API para la dashboard unificada de QA-FRAMEWORK",
     version="0.1.0",
-    openapi_url="/api/v1/openapi.json",
-    docs_url="/api/v1/docs",
-    redoc_url="/api/v1/redoc",
+    openapi_url=None if settings.is_production else "/api/v1/openapi.json",
+    docs_url=None if settings.is_production else "/api/v1/docs",
+    redoc_url=None if settings.is_production else "/api/v1/redoc",
 )
 
 # CORS middleware

--- a/dashboard/backend/tests/unit/test_config_security.py
+++ b/dashboard/backend/tests/unit/test_config_security.py
@@ -1,0 +1,89 @@
+"""Security behaviour of dashboard/backend/config.py Settings (card 2972521c).
+
+Incident 112853a6 (CWE-798): a committed SECRET_KEY default let anyone forge
+JWTs against the public staging. Contracts under test:
+
+- Production MUST crash at boot when JWT_SECRET_KEY / SECRET_KEY or
+  DATABASE_URL are missing (_validate_production_config, fail closed).
+- The development-only fallback secret must NOT be a committed constant:
+  it is generated per-process (ephemeral, high-entropy, non-guessable) and
+  only ever applied outside production.
+"""
+
+import pytest
+
+from config import Settings
+
+PROD = {"ENVIRONMENT": "production", "DATABASE_URL": "postgresql://u:p@h:5432/d"}
+
+
+def _scrub(monkeypatch):
+    for var in ("SECRET_KEY", "JWT_SECRET_KEY", "DATABASE_URL", "ENVIRONMENT"):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestProductionFailsClosed:
+    def test_missing_secret_key_raises(self, monkeypatch):
+        _scrub(monkeypatch)
+        for k, v in PROD.items():
+            monkeypatch.setenv(k, v)
+        with pytest.raises(ValueError, match="JWT_SECRET_KEY"):
+            Settings()
+
+    def test_missing_database_url_raises(self, monkeypatch):
+        _scrub(monkeypatch)
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("SECRET_KEY", "unit-test-signing-key-0123456789abcdef")
+        with pytest.raises(ValueError, match="DATABASE_URL"):
+            Settings()
+
+    def test_with_explicit_env_boots(self, monkeypatch):
+        _scrub(monkeypatch)
+        expected = "unit-test-signing-key-0123456789abcdef"
+        for k, v in PROD.items():
+            monkeypatch.setenv(k, v)
+        monkeypatch.setenv("SECRET_KEY", expected)
+        settings = Settings()
+        assert settings.is_production
+        assert settings.secret_key == expected
+
+
+class TestDevFallbackIsEphemeral:
+    def test_fallback_is_random_and_long(self, monkeypatch):
+        _scrub(monkeypatch)
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        settings = Settings()
+        assert settings.secret_key
+        assert len(settings.secret_key) >= 32
+        assert "dev-secret-key" not in settings.secret_key
+        assert "dev-jwt-secret" not in settings.secret_key
+
+    def test_fallback_differs_between_processes(self, monkeypatch):
+        _scrub(monkeypatch)
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        assert Settings().secret_key != Settings().secret_key
+
+    def test_fallback_warns(self, monkeypatch):
+        _scrub(monkeypatch)
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        with pytest.warns(UserWarning, match="JWT_SECRET_KEY not set"):
+            Settings()
+
+    def test_explicit_dev_secret_is_preserved(self, monkeypatch):
+        _scrub(monkeypatch)
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        monkeypatch.setenv("SECRET_KEY", "explicit-dev-key-0123456789abcdef012345")
+        settings = Settings()
+        assert settings.secret_key == "explicit-dev-key-0123456789abcdef012345"
+
+
+class TestProductionNeverFallsBack:
+    def test_production_secret_is_never_replaced(self, monkeypatch):
+        """The dev fallback must not touch a production instance."""
+        _scrub(monkeypatch)
+        expected = "prod-key-unit-test-0123456789abcdefghijklmnop"
+        for k, v in PROD.items():
+            monkeypatch.setenv(k, v)
+        monkeypatch.setenv("SECRET_KEY", expected)
+        settings = Settings()
+        assert settings.secret_key == expected

--- a/dashboard/backend/tests/unit/test_docs_disabled_in_production.py
+++ b/dashboard/backend/tests/unit/test_docs_disabled_in_production.py
@@ -1,0 +1,90 @@
+"""API docs must be disabled in production (card 2972521c, finding F3).
+
+main.py mounted /api/v1/docs, /api/v1/openapi.json and /api/v1/redoc
+unconditionally — verified live as 200 on the public staging. Contract:
+
+- development: docs mounted (200) so local DX is unchanged;
+- production: docs/openapi/redoc absent (404), app still serves traffic;
+- production boot without an explicit SECRET_KEY crashes (fail closed).
+"""
+
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+DOCS_PATHS = ("/api/v1/docs", "/api/v1/openapi.json", "/api/v1/redoc")
+
+PROD_ENV = {
+    "ENVIRONMENT": "production",
+    "SECRET_KEY": "docs-test-signing-key-0123456789abcdef",
+    "DATABASE_URL": "postgresql://u:p@h:5432/d",
+}
+
+
+@pytest.fixture()
+def dev_app(monkeypatch):
+    for var in ("ENVIRONMENT", "QA_VISUAL_ENABLED", "ACCURACY_TESTING_ENABLED"):
+        monkeypatch.delenv(var, raising=False)
+    import config as dashboard_config
+    import main as dashboard_main
+
+    importlib.reload(dashboard_config)
+    app = importlib.reload(dashboard_main).app
+    yield app
+    importlib.reload(dashboard_config)
+    importlib.reload(dashboard_main)
+
+
+@pytest.fixture()
+def production_app(monkeypatch):
+    for var, value in PROD_ENV.items():
+        monkeypatch.setenv(var, value)
+    import config as dashboard_config
+    import main as dashboard_main
+
+    importlib.reload(dashboard_config)
+    app = importlib.reload(dashboard_main).app
+    yield app
+    monkeypatch.undo()
+    importlib.reload(dashboard_config)
+    importlib.reload(dashboard_main)
+
+
+@pytest.fixture()
+def dev_client(dev_app):
+    return TestClient(dev_app)
+
+
+@pytest.fixture()
+def prod_client(production_app):
+    return TestClient(production_app)
+
+
+class TestDocsInDevelopment:
+    @pytest.mark.parametrize("path", DOCS_PATHS)
+    def test_docs_mounted_in_dev(self, dev_client, path):
+        assert dev_client.get(path).status_code == 200
+
+
+class TestDocsInProduction:
+    @pytest.mark.parametrize("path", DOCS_PATHS)
+    def test_docs_absent_in_production(self, prod_client, path):
+        assert prod_client.get(path).status_code == 404
+
+    def test_api_still_serves_traffic_in_production(self, prod_client):
+        assert prod_client.get("/health").status_code == 200
+
+
+class TestProductionBootCrashesWithoutSecret:
+    def test_config_reload_without_secret_raises(self, monkeypatch):
+        for var, value in PROD_ENV.items():
+            monkeypatch.setenv(var, value)
+        monkeypatch.delenv("SECRET_KEY", raising=False)
+        monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+        import config as dashboard_config
+
+        with pytest.raises(ValueError, match="JWT_SECRET_KEY"):
+            importlib.reload(dashboard_config)
+        monkeypatch.undo()
+        importlib.reload(dashboard_config)

--- a/dashboard/backend/tests/unit/test_no_committed_secret_defaults.py
+++ b/dashboard/backend/tests/unit/test_no_committed_secret_defaults.py
@@ -1,0 +1,93 @@
+"""Repo guard against committed secret defaults (card 2972521c, incident 112853a6).
+
+The staging SECRET_KEY default committed in this public repo allowed forging
+JWTs against qa.sabatech.dev (CWE-798, HIGH 8.6). These tests are the
+executable form of the card acceptance criteria so the defaults cannot be
+reintroduced silently:
+
+- docker-compose.unified.yml must declare SECRET_KEY as required
+  (``${SECRET_KEY:?...}``) with NO committed fallback.
+- No tracked file may carry the known dev-secret literals
+  ("dev-secret-key" / "dev-jwt-secret") outside the tests of this change.
+"""
+
+import subprocess
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    """Git toplevel, robust to this file's nesting depth."""
+    out = subprocess.run(
+        ["git", "-C", str(Path(__file__).resolve().parent), "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    return Path(out)
+
+
+REPO_ROOT = _repo_root()
+UNIFIED_COMPOSE = REPO_ROOT / "docker-compose.unified.yml"
+
+FORBIDDEN_LITERALS = ("dev-secret-key", "dev-jwt-secret")
+
+# File extensions whose tracked contents are scanned for secret literals.
+SCANNED_SUFFIXES = {
+    ".py",
+    ".yml",
+    ".yaml",
+    ".json",
+    ".md",
+    ".txt",
+    ".sh",
+    ".cfg",
+    ".ini",
+    ".toml",
+    ".example",
+    ".env",
+}
+
+
+def _tracked_files() -> list[str]:
+    out = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "ls-files"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def test_unified_compose_secret_key_has_no_committed_default():
+    """SECRET_KEY must be required in the unified compose, never defaulted."""
+    content = UNIFIED_COMPOSE.read_text()
+    assert "SECRET_KEY=" in content
+    # No inline default fallback may be committed for SECRET_KEY.
+    assert "SECRET_KEY=${SECRET_KEY:-" not in content
+    assert "dev-secret-key" not in content
+    # The variable must be declared required (compose fails fast when unset):
+    # `${SECRET_KEY:?...}` — the ":?" without a following default is the
+    # hard-requirement marker in compose interpolation syntax.
+    assert "SECRET_KEY=${SECRET_KEY:?" in content
+    assert "SECRET_KEY=${SECRET_KEY:-" not in content
+
+
+def test_tracked_files_contain_no_dev_secret_literals():
+    """AC (a)/(c): the known dev-secret literals must not exist in tracked
+    files outside the tests introduced by this change."""
+    offenders: list[str] = []
+    for tracked in _tracked_files():
+        path = REPO_ROOT / tracked
+        if path.suffix.lower() not in SCANNED_SUFFIXES and ".env" not in path.name:
+            continue
+        # Tests of this change may reference the literals as guards.
+        if tracked.startswith("dashboard/backend/tests/"):
+            continue
+        try:
+            text = path.read_text(errors="ignore")
+        except OSError:
+            continue
+        for literal in FORBIDDEN_LITERALS:
+            if literal in text:
+                offenders.append(f"{tracked}: contains '{literal}'")
+    assert not offenders, "Committed secret defaults found:\n" + "\n".join(offenders)

--- a/dashboard/backend/tests/unit/test_no_committed_secret_defaults.py
+++ b/dashboard/backend/tests/unit/test_no_committed_secret_defaults.py
@@ -9,6 +9,9 @@ reintroduced silently:
   (``${SECRET_KEY:?...}``) with NO committed fallback.
 - No tracked file may carry the known dev-secret literals
   ("dev-secret-key" / "dev-jwt-secret") outside the tests of this change.
+- Ronda 2 (review step 3): ANY tracked compose file (unified, dashboard,
+  railway, or future ones) must never declare SECRET_KEY/JWT_SECRET_KEY with
+  a committed default (``${VAR:-...}``) — required or pass-through only.
 """
 
 import subprocess
@@ -30,6 +33,9 @@ REPO_ROOT = _repo_root()
 UNIFIED_COMPOSE = REPO_ROOT / "docker-compose.unified.yml"
 
 FORBIDDEN_LITERALS = ("dev-secret-key", "dev-jwt-secret")
+
+# Secret env vars that compose files must never default.
+COMPOSE_SECRET_VARS = ("SECRET_KEY", "JWT_SECRET_KEY")
 
 # File extensions whose tracked contents are scanned for secret literals.
 SCANNED_SUFFIXES = {
@@ -70,6 +76,26 @@ def test_unified_compose_secret_key_has_no_committed_default():
     # hard-requirement marker in compose interpolation syntax.
     assert "SECRET_KEY=${SECRET_KEY:?" in content
     assert "SECRET_KEY=${SECRET_KEY:-" not in content
+
+
+def test_compose_files_never_default_secret_env_vars():
+    """AC ronda 2: every tracked compose file (unified, dashboard, railway or
+    any future one) must declare secret env vars as required
+    (``${VAR:?...}``) or pass-through (``${VAR}``), never with a committed
+    default fallback (``${VAR:-...}``)."""
+    offenders: list[str] = []
+    for tracked in _tracked_files():
+        path = Path(tracked)
+        if not (path.name.startswith("docker-compose") and path.suffix in (".yml", ".yaml")):
+            continue
+        text = (REPO_ROOT / tracked).read_text(errors="ignore")
+        for var in COMPOSE_SECRET_VARS:
+            if f"{var}=${{{var}:-" in text:
+                offenders.append(
+                    f"{tracked}: {var} declared with committed default "
+                    f"(${{{var}:-...}}) — use ${{{var}:?required}} instead"
+                )
+    assert not offenders, "Compose files must not default secret env vars:\n" + "\n".join(offenders)
 
 
 def test_tracked_files_contain_no_dev_secret_literals():

--- a/dashboard/docker-compose.yml
+++ b/dashboard/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - DATABASE_URL=postgresql+asyncpg://${POSTGRES_USER:-qa_user}:${POSTGRES_PASSWORD:-qa_password}@db:5432/${POSTGRES_DB:-qa_framework_db}
       - REDIS_HOST=redis
       - REDIS_PORT=6379
-      - SECRET_KEY=${SECRET_KEY:-your-secret-key-change-in-production}
+      - SECRET_KEY=${SECRET_KEY:?SECRET_KEY is required - set it via env or a local overrides file}
     depends_on:
       - db
       - redis

--- a/dashboard/docs/api-guide.md
+++ b/dashboard/docs/api-guide.md
@@ -23,7 +23,7 @@ The QA-Framework Dashboard API provides a comprehensive RESTful interface for ma
 - **JSON Format**: All requests and responses use JSON
 - **Async Support**: Full async/await support for optimal performance
 - **Type Safety**: Pydantic models for request/response validation
-- **Auto-generated Documentation**: Interactive Swagger UI at `/api/v1/docs`
+- **Auto-generated Documentation**: Interactive Swagger UI at `/api/v1/docs` (development only — disabled when `ENVIRONMENT=production`)
 - **Structured Logging**: Every request is logged with unique request IDs
 
 ### Key Features

--- a/docker-compose.unified.yml
+++ b/docker-compose.unified.yml
@@ -15,7 +15,10 @@ services:
       - DATABASE_URL=postgresql://qa_user:qa_pass@postgres:5432/qa_dashboard
       - REDIS_HOST=redis
       - REDIS_PORT=6379
-      - SECRET_KEY=${SECRET_KEY:-dev-secret-key-change-in-production}
+      # Required: no committed fallback. Provide via env or an overrides
+      # file (e.g. docker-compose.staging-overrides.yml, untracked, chmod 600).
+      # docker compose fails fast when the variable is unset.
+      - SECRET_KEY=${SECRET_KEY:?SECRET_KEY is required - set it via env or a local overrides file}
       - ENVIRONMENT=production
       - LOG_LEVEL=INFO
     depends_on:

--- a/docs/RAILWAY_DEPLOY_DIAGNOSTIC.md
+++ b/docs/RAILWAY_DEPLOY_DIAGNOSTIC.md
@@ -93,9 +93,9 @@ CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000} >> /tmp/s
 2. Verificar que existan:
    - `DATABASE_URL` = `${{Postgres.DATABASE_URL}}`
    - `REDIS_URL` = `${{Redis.REDIS_URL}}`
-   - `JWT_SECRET_KEY` = `qa-framework-production-secret-key-change-in-production-2026`
+   - `JWT_SECRET_KEY` = `PLACEHOLDER-REDACTED-2026-08-26`
    - `STRIPE_API_KEY` = `sk_live_...`
-   - `STRIPE_WEBHOOK_SECRET` = `whsec_QcsmAtCAuUTtINlsrkDSjrynqgxpcrKJ`
+   - `STRIPE_WEBHOOK_SECRET` = `PLACEHOLDER-REDACTED-2026-08-26`
    - `ENABLE_BILLING` = `true`
    - `ENVIRONMENT` = `production`
 

--- a/docs/RAILWAY_ENV_VARS.md
+++ b/docs/RAILWAY_ENV_VARS.md
@@ -28,14 +28,14 @@ Estas variables DEBEN estar configuradas en Railway Dashboard para que el backen
 
 | Variable | Valor | Descripción |
 |----------|-------|-------------|
-| `JWT_SECRET_KEY` | `qa-framework-production-secret-key-change-in-production-2026` | Clave secreta para JWT tokens |
+| `JWT_SECRET_KEY` | `PLACEHOLDER-REDACTED-2026-08-26` | Clave secreta para JWT tokens |
 
 ### Pagos (Stripe)
 
 | Variable | Valor | Descripción |
 |----------|-------|-------------|
 | `STRIPE_API_KEY` | `sk_live_...` | API key de Stripe (LIVE) |
-| `STRIPE_WEBHOOK_SECRET` | `whsec_QcsmAtCAuUTtINlsrkDSjrynqgxpcrKJ` | Secreto del webhook de Stripe |
+| `STRIPE_WEBHOOK_SECRET` | `PLACEHOLDER-REDACTED-2026-08-26` | Secreto del webhook de Stripe |
 | `ENABLE_BILLING` | `true` | Habilitar funcionalidades de billing |
 
 ### Configuración General
@@ -70,9 +70,9 @@ value = "${{Redis.REDIS_URL}}"
 Ir a Railway Dashboard → Proyecto → Servicio → Variables y añadir manualmente:
 
 ```
-JWT_SECRET_KEY=qa-framework-production-secret-key
+JWT_SECRET_KEY=PLACEHOLDER-REDACTED-2026-08-26
 STRIPE_API_KEY=sk_live_YOUR_KEY_HERE
-STRIPE_WEBHOOK_SECRET=whsec_YOUR_SECRET_HERE
+STRIPE_WEBHOOK_SECRET=PLACEHOLDER-REDACTED-2026-08-26
 ENABLE_BILLING=true
 ENVIRONMENT=production
 FRONTEND_URL=https://frontend-phi-three-52.vercel.app


### PR DESCRIPTION
# fix(security): erradicar defaults de secrets + docs condicionales en production

Card workboard 2972521c — cierra F1-residual y F3 del incidente 112853a6 (SECRET_KEY default público → auth bypass HIGH 8.6 en staging) y la exposición de secrets en docs (b5ef22c6, MEDIUM 6.4).

## Qué cambia (3 commits, 13 files, +437/−93)

- **Fail-closed a 3 capas:** `docker-compose.unified.yml` + `dashboard/docker-compose.yml` usan `${SECRET_KEY:*** (requerida, sin default commiteado) · pydantic `Field(..., min_length=32)` sin defaults en `environment_config.py` · `ValueError` en `_validate_production_config` si production sin env completo. Dev-fallback = `secrets.token_urlsafe(48)` efímero, solo no-production.
- **Docs API off en production (F3):** `main.py` monta `docs_url/openapi_url/redoc_url = None if settings.is_production` — verificado 404×4 en production-mode real (browser).
- **Redacción de secrets en docs:** los 2 secrets de era-Railway (`RAILWAY_ENV_VARS.md`, `RAILWAY_DEPLOY_DIAGNOSTIC.md`) → `PLACEHOLDER-REDACTED-2026-08-26`. Vigencia: MUERTOS (sin consumidor vivo — ver card b5ef22c6). Historia git NO reescrita (decisión pendiente dueño del repo: gitleaks recomendado).
- **Guard de regresión:** `test_compose_files_never_default_secret_env_vars` prohíbe `${VAR:-` para SECRET_KEY/JWT_SECRET_KEY en TODOS los compose trackeados.

## Pipeline completo (6/6 gates verdes)

| Gate | Resultado | Proof card |
|---|---|---|
| Review (R2) | APPROVED — RED→GREEN reconstruido | fab0d85d |
| Security | PASSED — fail-closed + redacción + SAST limpio | 04d4ac89 |
| QA | PASSED — 0 regresiones (diff de fallos vacío 23/23), coverage config 82→91% | fbefccad |
| E2E | PASSED 5/5 — login real, docs 404×4 browser, anon 401, 0 console errors, cleanup 0 residuos | 3fc9de8b |

Suite: 625 passed vs 606 base (+19 tests nuevos, fallos pre-existentes idénticos a main).

## Post-merge (plan)

1. Redeploy staging (`docker compose -f unified -f staging-overrides up -d backend` — overrides ya lleva secrets 64-char)
2. Smoke: docs 4×404 app-level, token nuevo 200 / viejo 401, frontend 200
3. Verificación anónima raw.githubusercontent (defaults fuera de main)
4. Barrera nginx (deny docs) queda como defense-in-depth permanente
