### PR TITLE
chore: housekeeping post-#154 (pins reproducibles + redis teardown-noise + majors deny-list)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@
 # bumps land in isolated PRs. stripe is GATED (Joker): excluded from every
 # group in ecosystems where it can appear (pip root, pip backend, npm);
 # it keeps receiving individual (ungrouped) PRs as before.
+# 2026-08-27: majors groups also exclude high-blast-radius frameworks (card
+# f28cecdb) — pip: sqlalchemy, fastapi, starlette, pydantic; npm: next,
+# react, vite. Only innocuous majors get bundled; the excluded ones fall
+# back to individual PRs for isolated review, same as stripe.
 
 version: 2
 updates:
@@ -25,6 +29,10 @@ updates:
           - "major"
         exclude-patterns:
           - "stripe"
+          - "sqlalchemy"
+          - "fastapi"
+          - "starlette"
+          - "pydantic"
       pip-root-minors-patch:
         update-types:
           - "minor"
@@ -55,6 +63,10 @@ updates:
           - "major"
         exclude-patterns:
           - "stripe"
+          - "sqlalchemy"
+          - "fastapi"
+          - "starlette"
+          - "pydantic"
       pip-backend-minors-patch:
         update-types:
           - "minor"
@@ -86,6 +98,9 @@ updates:
           - "major"
         exclude-patterns:
           - "@stripe/*"
+          - "next"
+          - "react"
+          - "vite"
       npm-frontend-minors-patch:
         update-types:
           - "minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -100,6 +100,7 @@ updates:
           - "@stripe/*"
           - "next"
           - "react"
+          - "react-dom"
           - "vite"
       npm-frontend-minors-patch:
         update-types:

--- a/dashboard/backend/requirements.txt
+++ b/dashboard/backend/requirements.txt
@@ -21,13 +21,13 @@ pytest==9.0.3
 pytest-asyncio==1.4.0
 pytest-cov==7.1.0
 pytest-playwright==0.9.0
-playwright>=1.62,<2.0
+playwright==1.62.0
 httpx==0.27.2
 allure-pytest==2.13.5
 psycopg2-binary==2.9.12
 python-dotenv==1.2.2
 structlog==24.4.0
-locust>=2.31,<3.0
+locust==2.46.4
 stripe==10.12.0
 email-validator==2.2.0
 bleach==6.4.0

--- a/dashboard/backend/tests/conftest.py
+++ b/dashboard/backend/tests/conftest.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
 from dotenv import load_dotenv
 
 # Mock Redis to avoid connection errors during import
@@ -56,3 +57,65 @@ print(f"Python path: {sys.path[:3]}")  # Show first 3 paths
 from core.logging_config import configure_logging
 
 configure_logging(log_level="WARNING", environment="test")
+
+
+async def _purge_shared_rate_limit_keys() -> None:
+    """Delete ``ratelimit:*`` keys left in the shared Redis by test traffic.
+
+    Best-effort: a no-op when ``redis.asyncio`` is still the conftest
+    MagicMock or when no local Redis is reachable.
+    """
+    try:
+        import redis.asyncio as aioredis
+
+        cleanup = aioredis.from_url(
+            os.getenv("REDIS_URL", "redis://127.0.0.1:6379/0"),
+            decode_responses=True,
+        )
+        try:
+            async for key in cleanup.scan_iter("ratelimit:*"):
+                await cleanup.delete(key)
+        finally:
+            try:
+                await cleanup.aclose()
+            except AttributeError:  # older redis-py names it close()
+                await cleanup.close()
+    except Exception:
+        pass
+
+
+async def _aclose_client(client) -> None:
+    """Close an async Redis client regardless of redis-py version."""
+    close = getattr(client, "aclose", None) or getattr(client, "close", None)
+    if close is not None:
+        await close()
+
+
+@pytest.fixture(autouse=True)
+async def _isolated_rate_limit_redis():
+    """Keep the shared async Redis client loop-local and stateless per test.
+
+    ``services.cache_service.get_redis_client()`` caches an aioredis
+    singleton bound to the event loop of the first test that used it.
+    pytest-asyncio gives every test a fresh loop, so later tests reused
+    a pool tied to a closed loop -> ``Event loop is closed`` error logs
+    from RateLimitMiddleware, plus real-Redis ``ratelimit:*`` counters
+    leaking across tests/runs (100-entry hourly cap -> flaky 429s).
+
+    Purge shared counters before each test; after each test close the
+    stale client and reset the singleton so the next test lazily builds
+    a fresh, loop-local one. Both steps are best-effort (mocks and
+    closed-loop pools must never fail a test here).
+    """
+    await _purge_shared_rate_limit_keys()
+    yield
+    import services.cache_service as cache_service
+
+    client = cache_service._async_redis_client
+    cache_service._async_redis_client = None
+    if client is None:
+        return
+    try:
+        await _aclose_client(client)
+    except Exception:
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ httpx==0.26.0
 requests==2.34.2  # aligned with pyproject.toml; locust>=2.31 requires requests>=2.32.2
 
 # UI Testing
-playwright>=1.62,<2.0
+playwright==1.62.0
 selenium==4.16.0
 
 # Data Generation
@@ -31,7 +31,7 @@ pydantic-extra-types==2.6.0
 allure-python-commons==2.13.5
 
 # Performance Testing
-locust>=2.31,<3.0
+locust==2.46.4
 pytest-benchmark==5.2.3
 
 # Security Testing


### PR DESCRIPTION
Card f28cecdb · 3 sub-fixes derivados del ciclo PR #154 (88ff50d):

(1) fix(tests): redis rate-limit client loop-local + stateless per test — elimina 'Event loop is closed' post-summary y leak de counters ratelimit:* (429s flaky entre corridas). Autouse fixture purga ratelimit:* pre-test y resetea singleton post-test. Suite backend: 240p/0F ×N sin noise (verificado por builder).
(2) chore(ci): deny-list high-blast majors en dependabot group {majors} (sqlalchemy/fastapi/starlette/pydantic + next/react/vite) — bundlean solo majors inocuos; excluidos caen a PR individual (estilo stripe-excludes).
(3) chore(deps): pins ==resuelto playwright==1.62.0 / locust==2.46.4 en requirements backend (reproducibilidad, advisory reviewer cf45697a).

Gates: reviewer + security + QA pytest manual en curso — NO MERGE.
Refs: card f28cecdb · derivas cf45697a (reviewer advisory) · 3c079c0a (security O-2) · GATE-REPORT pr154 (qa noise)