### PR TITLE
chore(deps): deny-list bcrypt y eslint-plugin-react-refresh hasta adaptacion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@
 # f28cecdb) — pip: sqlalchemy, fastapi, starlette, pydantic; npm: next,
 # react, vite. Only innocuous majors get bundled; the excluded ones fall
 # back to individual PRs for isolated review, same as stripe.
+# 2026-08-28: deny-list bcrypt (pip-backend-majors) and
+# eslint-plugin-react-refresh (npm-frontend-minors-patch): their grouped
+# PRs (#156, #167) were reviewed and closed, and dependabot re-opens them
+# weekly. Excluded until the blocking migrations land (card fbe1e86d).
 
 version: 2
 updates:
@@ -67,6 +71,9 @@ updates:
           - "fastapi"
           - "starlette"
           - "pydantic"
+          # bcrypt 5.x breaks passlib hashing for >72-byte secrets; PR #156
+          # closed until the auth adaptation lands (card fbe1e86d).
+          - "bcrypt"
       pip-backend-minors-patch:
         update-types:
           - "minor"
@@ -108,6 +115,9 @@ updates:
           - "patch"
         exclude-patterns:
           - "@stripe/*"
+          # eslint-plugin-react-refresh >=0.4.20 requires eslint 9; PR #167
+          # closed until the eslint 9 migration lands (card fbe1e86d).
+          - "eslint-plugin-react-refresh"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"


### PR DESCRIPTION
## Motivo

Dependabot re-abre semanalmente los PRs agrupados que ya fueron revisados y cerrados, porque los paquetes bloqueados siguen dentro de los grupos. Este PR los saca de los grupos (deny-list), siguiendo el estilo del commit 06f8417 (policy deny-list ya usada para stripe y frameworks high-blast).

## Cambios (scope: deny-list only, 1 archivo)

Mapeo grupo real -> exclusion aplicada:

| Paquete | Grupo real | Motivo | Ref |
|---|---|---|---|
| `bcrypt` | `pip-backend-majors` (pip, `/dashboard/backend`) | bcrypt 5.x rompe passlib con secrets >72 bytes; cerrado hasta adaptacion de auth | #156 |
| `eslint-plugin-react-refresh` | `npm-frontend-minors-patch` (npm, `/dashboard/frontend`) | exige eslint 9; cerrado hasta migracion | #167 |

Notas de mapeo:
- `bcrypt==4.1.2` solo existe en `dashboard/backend/requirements.txt` (el manifest root no lo declara), por eso se excluye unicamente en `pip-backend-majors` y no en `pip-root-majors`.
- `eslint-plugin-react-refresh@^0.4.4` solo existe en `dashboard/frontend/package.json`.

## Verificacion

- `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` -> OK
- `git diff --stat` -> solo `.github/dependabot.yml` (+10/-0)

## Fuera de alcance

- NO se toca nada mas del archivo ni de otros archivos.
- Las exclusiones son reversibles: al aterrizar la adaptacion de passlib/bcrypt (#156) y la migracion a eslint 9 (#167), quitar las entradas de `exclude-patterns`.

Card fbe1e86d (item 5 de 5).