### PR TITLE
chore: PR dummy — validacion e2e previews Coolify (card 52a85645)

### DIFF
--- a/.github/workflows/pr-deploy-coolify.yml
+++ b/.github/workflows/pr-deploy-coolify.yml
@@ -245,8 +245,17 @@ jobs:
           esac
           CID=$(docker ps -q --filter "ancestor=${IMG}:${IMG_TAG}" | head -1)
           if [ -z "${CID}" ]; then echo "ERROR: contenedor no encontrado (${IMG}:${IMG_TAG})"; exit 1; fi
-          docker exec "${CID}" python3 -c "import urllib.request; r=urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=5); print('probe /health ->', r.status)" >/dev/null
-          echo "probe /health OK"
+          PROBE_OK=""
+          for i in $(seq 1 12); do
+            if docker exec "${CID}" python3 -c "import urllib.request; r=urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=5); print('probe /health ->', r.status)" >/dev/null 2>&1; then
+              PROBE_OK=yes
+              echo "probe /health OK (intento ${i})"
+              break
+            fi
+            echo "[probe ${i}/12] app aun arrancando..."
+            sleep 5
+          done
+          [ "${PROBE_OK}" = "yes" ] || { echo "ERROR: probe /health fallo tras 60s"; exit 1; }
           echo "status=${ASTAT}" >> "${GITHUB_OUTPUT}"
           echo "app_uuid=${APP_UUID}" >> "${GITHUB_OUTPUT}"
           rm -f "${HDR}"
@@ -375,7 +384,17 @@ jobs:
           esac
           CID=$(docker ps -q --filter "ancestor=${IMG}:${IMG_TAG}" | head -1)
           if [ -z "${CID}" ]; then echo "ERROR: contenedor no encontrado (${IMG}:${IMG_TAG})"; exit 1; fi
-          docker exec "${CID}" wget -q -O /dev/null http://127.0.0.1:3000/ && echo "probe / (vite dev 3000) OK"
+          PROBE_OK=""
+          for i in $(seq 1 12); do
+            if docker exec "${CID}" wget -q -O /dev/null http://127.0.0.1:3000/ 2>/dev/null; then
+              PROBE_OK=yes
+              echo "probe / (vite dev 3000) OK (intento ${i})"
+              break
+            fi
+            echo "[probe ${i}/12] app aun arrancando..."
+            sleep 5
+          done
+          [ "${PROBE_OK}" = "yes" ] || { echo "ERROR: probe / fallo tras 60s"; exit 1; }
           echo "status=${ASTAT}" >> "${GITHUB_OUTPUT}"
           echo "app_uuid=${APP_UUID}" >> "${GITHUB_OUTPUT}"
           rm -f "${HDR}"

--- a/docs/PREVIEW-VALIDATION-2026-08-28.md
+++ b/docs/PREVIEW-VALIDATION-2026-08-28.md
@@ -1,0 +1,9 @@
+# Validación de previews Coolify — 2026-08-28
+
+PR dummy para validar el pipeline end-to-end de previews (card 52a85645):
+
+1. Deploy de apps backend+frontend en Coolify vía API (runner `coolify-deploy`).
+2. Probes in-container (backend `/health`, frontend `:5173`).
+3. Cleanup automático al cerrar este PR (se cerrará SIN merge).
+
+Este fichero es efímero: solo existe para disparar el pipeline.


### PR DESCRIPTION
PR dummy de validación (card 52a85645, decisión 1b):

- Valida deploy verde: gate → artifacts → deploy backend+frontend vía runner `coolify-deploy` → apps en Coolify → probes.
- Después se **cierra sin merge** para validar cleanup-on-close (apps eliminadas de Coolify, verificado vía API).

Rollback: ninguno necesario (cleanup automático).
