### PR TITLE
fix(ci): REGISTRY sin definir en env de workflow (card 52a85645)

### DIFF
--- a/.github/workflows/pr-deploy-coolify.yml
+++ b/.github/workflows/pr-deploy-coolify.yml
@@ -9,6 +9,7 @@ on:
 env:
   PYTHON_VERSION: "3.11"
   NODE_VERSION: "26"
+  REGISTRY: localhost:5000
 
 # NOTE: preview deploys corren en runner self-hosted (label coolify-deploy) — card 52a85645.
 # NOTE: the SECURITY GATE (security-gate job) IS blocking/fail-closed (card 650387a1, R3):


### PR DESCRIPTION
Los jobs deploy fallaron en el PR dummy #181 con 'REGISTRY: variable sin asignar' (set -u): el workflow usa ${REGISTRY} en load/tag/push/cleanup pero el env de nivel workflow nunca lo definió. Fix de una línea. Evidencia: run 33191631061.