### PR TITLE
feat(auth): adapt passlib hashing for bcrypt 5 (>72 bytes explicit rejection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **bcrypt 5 adaptation for the dashboard backend auth (card fbe1e86d,
+  closes the gap that blocked PR #156)**:
+  - `dashboard/backend/services/auth_service.py` drops the unmaintained
+    passlib 1.7.4 wrapper (its backend-initialization probe relies on the
+    silent >72-byte truncation that bcrypt 5 removed, breaking every
+    hash/verify call) and hashes directly with the `bcrypt` package.
+  - Passwords whose UTF-8 encoding exceeds 72 bytes are now rejected
+    explicitly with a domain error (`PasswordTooLongError`) — no silent
+    truncation, no raw `ValueError` escaping as HTTP 500.
+  - `create_user_service` maps the rejection to a controlled
+    `400 Bad Request` ("Password too long: bcrypt accepts a maximum of
+    72 bytes"); login with an oversized password is a plain
+    authentication failure.
+  - Hash output stays `$2b$`/12 rounds, so existing stored hashes remain
+    verifiable (covered by a legacy-hash regression test).
+  - `dashboard/backend/requirements.txt`: `bcrypt==5.*`, `passlib`
+    removed (no remaining importers).
+
 - **Config hardening follow-ups from review R2 (card f3231394, deriva of
   card 2972521c / PR #147)**:
   - `dashboard/backend/config.py`: `ENVIRONMENT` is normalized

--- a/dashboard/backend/requirements.txt
+++ b/dashboard/backend/requirements.txt
@@ -8,8 +8,7 @@ pydantic==2.13.4
 pydantic-settings==2.15.0
 alembic==1.19.1
 python-jose[cryptography]>=3.5.0
-passlib[bcrypt]==1.7.4
-bcrypt==4.1.2
+bcrypt==5.*
 python-multipart>=0.0.32
 aiofiles==24.1.0
 websockets==14.0

--- a/dashboard/backend/services/__init__.py
+++ b/dashboard/backend/services/__init__.py
@@ -3,55 +3,57 @@ Services Module
 
 Provides all business logic services for the QA-Framework Dashboard.
 """
+
 from services.auth_service import (
     hash_password,
     verify_password,
+    PasswordTooLongError,
     create_access_token,
     authenticate_user,
     get_current_user,
-    login_for_access_token
+    login_for_access_token,
 )
 from services.user_service import (
     create_user_service,
     list_users_service,
     get_user_by_id,
     update_user_service,
-    delete_user_service
+    delete_user_service,
 )
 from services.suite_service import (
     create_suite_service,
     list_suites_service,
     get_suite_by_id,
     update_suite_service,
-    delete_suite_service
+    delete_suite_service,
 )
 from services.case_service import (
     create_case_service,
     list_cases_service,
     get_case_by_id,
     update_case_service,
-    delete_case_service
+    delete_case_service,
 )
 from services.execution_service import (
     create_execution_service,
     start_execution_service,
     stop_execution_service,
     list_executions_service,
-    get_execution_by_id
+    get_execution_by_id,
 )
 from services.dashboard_service import (
     get_stats_service,
     get_trends_service,
     get_recent_service,
     get_test_types_distribution,
-    get_performance_metrics
+    get_performance_metrics,
 )
 from services.email_service import (
     email_service,
     send_beta_invitation,
     send_welcome_email,
     send_test_report,
-    send_password_reset
+    send_password_reset,
 )
 from services.analytics_service import (
     get_analytics_service,
@@ -59,65 +61,59 @@ from services.analytics_service import (
     get_test_analytics,
     get_revenue_analytics,
     get_feature_usage_analytics,
-    get_dashboard_summary
+    get_dashboard_summary,
 )
 
 __all__ = [
     # Auth
-    'hash_password',
-    'verify_password',
-    'create_access_token',
-    'authenticate_user',
-    'get_current_user',
-    'login_for_access_token',
-    
+    "hash_password",
+    "verify_password",
+    "PasswordTooLongError",
+    "create_access_token",
+    "authenticate_user",
+    "get_current_user",
+    "login_for_access_token",
     # User
-    'create_user_service',
-    'list_users_service',
-    'get_user_by_id',
-    'update_user_service',
-    'delete_user_service',
-    
+    "create_user_service",
+    "list_users_service",
+    "get_user_by_id",
+    "update_user_service",
+    "delete_user_service",
     # Suite
-    'create_suite_service',
-    'list_suites_service',
-    'get_suite_by_id',
-    'update_suite_service',
-    'delete_suite_service',
-    
+    "create_suite_service",
+    "list_suites_service",
+    "get_suite_by_id",
+    "update_suite_service",
+    "delete_suite_service",
     # Case
-    'create_case_service',
-    'list_cases_service',
-    'get_case_by_id',
-    'update_case_service',
-    'delete_case_service',
-    
+    "create_case_service",
+    "list_cases_service",
+    "get_case_by_id",
+    "update_case_service",
+    "delete_case_service",
     # Execution
-    'create_execution_service',
-    'start_execution_service',
-    'stop_execution_service',
-    'list_executions_service',
-    'get_execution_by_id',
-    
+    "create_execution_service",
+    "start_execution_service",
+    "stop_execution_service",
+    "list_executions_service",
+    "get_execution_by_id",
     # Dashboard
-    'get_stats_service',
-    'get_trends_service',
-    'get_recent_service',
-    'get_test_types_distribution',
-    'get_performance_metrics',
-    
+    "get_stats_service",
+    "get_trends_service",
+    "get_recent_service",
+    "get_test_types_distribution",
+    "get_performance_metrics",
     # Email
-    'email_service',
-    'send_beta_invitation',
-    'send_welcome_email',
-    'send_test_report',
-    'send_password_reset',
-    
+    "email_service",
+    "send_beta_invitation",
+    "send_welcome_email",
+    "send_test_report",
+    "send_password_reset",
     # Analytics
-    'get_analytics_service',
-    'get_user_analytics',
-    'get_test_analytics',
-    'get_revenue_analytics',
-    'get_feature_usage_analytics',
-    'get_dashboard_summary'
+    "get_analytics_service",
+    "get_user_analytics",
+    "get_test_analytics",
+    "get_revenue_analytics",
+    "get_feature_usage_analytics",
+    "get_dashboard_summary",
 ]

--- a/dashboard/backend/services/auth_service.py
+++ b/dashboard/backend/services/auth_service.py
@@ -14,12 +14,12 @@ from datetime import datetime, timedelta
 from typing import Optional
 from uuid import uuid4
 
+import bcrypt
 from database import get_db_session
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
 from models import User
-from passlib.context import CryptContext
 from schemas import LoginRequest, TokenResponse, UserCreate, UserResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -35,8 +35,32 @@ from src.infrastructure.refresh_tokens.store import (
 # Initialize logger
 logger = get_logger(__name__)
 
-# Password hashing
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+# Password hashing (bcrypt 5 adaptation).
+#
+# passlib 1.7.4 is incompatible with bcrypt 5: its backend-initialization
+# probe relies on the silent truncation of passwords longer than 72 bytes,
+# which bcrypt 5 removed, so every hash/verify call fails at backend load.
+# We call the bcrypt package directly and enforce the 72-byte limit as an
+# explicit, controlled domain policy (no silent truncation, no raw
+# ValueError). Output stays $2b$-format, so existing stored hashes remain
+# verifiable.
+PASSWORD_MAX_BYTES = 72
+
+
+class PasswordTooLongError(ValueError):
+    """Password exceeds the 72-byte input limit of the bcrypt algorithm."""
+
+
+def _validate_password_bytes(password: str) -> bytes:
+    """Encode a password as UTF-8 and enforce the bcrypt size limit."""
+    password_bytes = password.encode("utf-8")
+    if len(password_bytes) > PASSWORD_MAX_BYTES:
+        raise PasswordTooLongError(
+            f"password cannot be longer than {PASSWORD_MAX_BYTES} bytes "
+            f"(got {len(password_bytes)} bytes); choose a shorter password"
+        )
+    return password_bytes
+
 
 # Refresh token rotation constants (card 3ae2e5c1, F-2 / OWASP API2)
 REFRESH_TOKEN_LIFETIME = timedelta(days=7)
@@ -76,16 +100,31 @@ security = HTTPBearer()
 
 
 def hash_password(password: str) -> str:
-    """Hash a password"""
+    """Hash a password.
+
+    Raises PasswordTooLongError when the UTF-8 encoding of the password
+    exceeds PASSWORD_MAX_BYTES (72): bcrypt 5 removed the silent
+    truncation of longer inputs, so oversized passwords are rejected
+    explicitly instead.
+    """
     logger.debug("Hashing password")
-    hashed = pwd_context.hash(password)
+    hashed = bcrypt.hashpw(_validate_password_bytes(password), bcrypt.gensalt())
     logger.debug("Password hashed successfully")
-    return hashed
+    return hashed.decode("ascii")
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-    """Verify a password against a hash"""
-    return pwd_context.verify(plain_password, hashed_password)
+    """Verify a password against a bcrypt hash ($2b$ format).
+
+    Oversized candidates (>72 bytes) can never match a storable hash —
+    hash_password rejects them at registration — so they are a plain
+    authentication failure instead of an error.
+    """
+    try:
+        plain_bytes = _validate_password_bytes(plain_password)
+    except PasswordTooLongError:
+        return False
+    return bcrypt.checkpw(plain_bytes, hashed_password.encode("ascii"))
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:

--- a/dashboard/backend/services/user_service.py
+++ b/dashboard/backend/services/user_service.py
@@ -11,7 +11,7 @@ from sqlalchemy import select, func
 
 from models import User
 from schemas import UserCreate, UserUpdate, UserResponse
-from services.auth_service import hash_password
+from services.auth_service import PasswordTooLongError, hash_password
 from core.logging_config import get_logger
 
 # Initialize logger
@@ -37,15 +37,23 @@ async def create_user_service(user_data: UserCreate, db: AsyncSession) -> User:
     # Check if email exists
     result = await db.execute(select(User).where(User.email == user_data.email))
     if result.scalar_one_or_none():
-        logger.warning(
-            "User creation failed - email already exists", email=user_data.email
-        )
+        logger.warning("User creation failed - email already exists", email=user_data.email)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Email already registered"
         )
 
-    # Create user
-    hashed_password = hash_password(user_data.password)
+    # Create user (bcrypt 5: reject >72-byte passwords explicitly, PR #156)
+    try:
+        hashed_password = hash_password(user_data.password)
+    except PasswordTooLongError as exc:
+        logger.warning(
+            "User creation failed - password exceeds 72-byte bcrypt limit",
+            username=user_data.username,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Password too long: bcrypt accepts a maximum of 72 bytes",
+        ) from exc
     db_user = User(
         username=user_data.username,
         email=user_data.email,
@@ -57,9 +65,7 @@ async def create_user_service(user_data: UserCreate, db: AsyncSession) -> User:
     await db.commit()
     await db.refresh(db_user)
 
-    logger.info(
-        "User created successfully", user_id=db_user.id, username=db_user.username
-    )
+    logger.info("User created successfully", user_id=db_user.id, username=db_user.username)
 
     return db_user
 
@@ -89,18 +95,14 @@ async def get_user_by_id(user_id: int, db: AsyncSession) -> User:
 
     if not user:
         logger.error("User not found", user_id=user_id)
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
     logger.debug("User retrieved successfully", user_id=user_id, username=user.username)
 
     return user
 
 
-async def update_user_service(
-    user_id: int, user_update: UserUpdate, db: AsyncSession
-) -> User:
+async def update_user_service(user_id: int, user_update: UserUpdate, db: AsyncSession) -> User:
     """Update a user"""
     logger.info("Updating user", user_id=user_id)
 
@@ -139,9 +141,7 @@ async def update_user_service(
     await db.commit()
     await db.refresh(user)
 
-    logger.info(
-        "User updated successfully", user_id=user_id, updated_fields=updated_fields
-    )
+    logger.info("User updated successfully", user_id=user_id, updated_fields=updated_fields)
 
     return user
 
@@ -162,6 +162,4 @@ async def delete_user_service(user_id: int, db: AsyncSession) -> None:
     user.is_active = False
     await db.commit()
 
-    logger.info(
-        "User soft deleted successfully", user_id=user_id, username=user.username
-    )
+    logger.info("User soft deleted successfully", user_id=user_id, username=user.username)

--- a/dashboard/backend/tests/services/test_user_service.py
+++ b/dashboard/backend/tests/services/test_user_service.py
@@ -3,13 +3,15 @@ Unit tests for user_service.py
 
 Tests all user management functions with mocked database sessions.
 """
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi import HTTPException
 
 import sys
 import os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 
 class TestCreateUserService:
@@ -106,6 +108,29 @@ class TestCreateUserService:
             await create_user_service(mock_user_data, mock_db)
 
         mock_db.add.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_user_rejects_password_over_72_bytes(self):
+        """bcrypt 5 adaptation: >72-byte passwords get a controlled 400."""
+        from services.user_service import create_user_service
+
+        mock_db = AsyncMock()
+        mock_user_data = MagicMock()
+        mock_user_data.username = "longpwduser"
+        mock_user_data.email = "long@example.com"
+        mock_user_data.password = "x" * 73
+        mock_user_data.is_active = True
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = mock_result
+
+        with pytest.raises(HTTPException) as exc_info:
+            await create_user_service(mock_user_data, mock_db)
+
+        assert exc_info.value.status_code == 400
+        assert "72" in str(exc_info.value.detail)
+        mock_db.add.assert_not_called()
 
 
 class TestListUsersService:

--- a/dashboard/backend/tests/unit/test_auth_service.py
+++ b/dashboard/backend/tests/unit/test_auth_service.py
@@ -3,10 +3,12 @@ Unit Tests for Auth Service
 
 Tests authentication, JWT generation, and user management.
 """
+
 import pytest
-pytest.importorskip('jose')
-pytest.importorskip('bcrypt')
-pytest.importorskip('asyncpg')
+
+pytest.importorskip("jose")
+pytest.importorskip("bcrypt")
+pytest.importorskip("asyncpg")
 from unittest.mock import Mock, AsyncMock, patch
 from datetime import datetime, timedelta
 from jose import jwt
@@ -17,10 +19,16 @@ from services.auth_service import (
     verify_password,
     create_access_token,
     authenticate_user,
-    get_current_user
+    get_current_user,
+    PasswordTooLongError,
 )
 from models import User
 from schemas import UserCreate, LoginRequest
+
+# Reference bcrypt hash of "test_pwd_123" ($2b$12$, 12 rounds) in the exact
+# format produced by the previous passlib 1.7.4 + bcrypt 4 stack. Password
+# hashes are algorithm-identical, so verification must keep accepting them.
+LEGACY_BCRYPT_HASH = "$2b$12$HyDcNXuJwAmu7K9rdC8iVOnBIZ1wlznn4VJKSGiVDvrWicowUxc3q"
 
 
 @pytest.mark.asyncio
@@ -31,7 +39,7 @@ class TestAuthService:
         """Test password hashing"""
         password = "test_pwd_123"  # Shorter password (< 72 bytes)
         hashed = hash_password(password)
-        
+
         # Verify it's hashed
         assert hashed != password
         assert hashed.startswith("$2b$")
@@ -41,7 +49,7 @@ class TestAuthService:
         """Test password verification with correct password"""
         password = "test_pwd_123"  # Shorter password (< 72 bytes)
         hashed = hash_password(password)
-        
+
         # Verify correct password
         assert verify_password(password, hashed) is True
 
@@ -49,7 +57,7 @@ class TestAuthService:
         """Test password verification with incorrect password"""
         password = "test_pwd_123"  # Shorter password (< 72 bytes)
         hashed = hash_password(password)
-        
+
         # Verify incorrect password
         assert verify_password("wrong_pwd", hashed) is False
 
@@ -57,13 +65,15 @@ class TestAuthService:
         """Test JWT token creation"""
         data = {"sub": "testuser"}
         token = create_access_token(data)
-        
+
         # Verify token is created
         assert token is not None
         assert isinstance(token, str)
-        
+
         # Decode and verify
-        payload = jwt.decode(token, settings.secret_key.get_secret_value(), algorithms=[settings.algorithm])
+        payload = jwt.decode(
+            token, settings.secret_key.get_secret_value(), algorithms=[settings.algorithm]
+        )
         assert payload["sub"] == "testuser"
         assert "exp" in payload
 
@@ -72,39 +82,41 @@ class TestAuthService:
         data = {"sub": "testuser"}
         expires = timedelta(minutes=15)
         token = create_access_token(data, expires)
-        
+
         # Decode and verify expiry
-        payload = jwt.decode(token, settings.secret_key.get_secret_value(), algorithms=[settings.algorithm])
+        payload = jwt.decode(
+            token, settings.secret_key.get_secret_value(), algorithms=[settings.algorithm]
+        )
         exp_time = datetime.fromtimestamp(payload["exp"])
-        
+
         # Should be approximately 15 minutes from now
         now = datetime.utcnow()
         delta = exp_time - now
-        
+
         assert 14 * 60 < delta.total_seconds() < 16 * 60
 
     async def test_authenticate_user_success(self):
         """Test successful user authentication"""
         # Mock database session
         mock_db = AsyncMock()
-        
+
         # Mock user
         user = User(
             id=1,
             username="testuser",
             email="test@example.com",
             hashed_password=hash_password("test_pwd_123"),  # Shorter password
-            is_active=True
+            is_active=True,
         )
-        
+
         # Mock database query
         mock_result = AsyncMock()
         mock_result.scalar_one_or_none = Mock(return_value=user)  # Sync mock
         mock_db.execute = AsyncMock(return_value=mock_result)
-        
+
         # Test authentication
         authenticated_user = await authenticate_user(mock_db, "testuser", "test_pwd_123")
-        
+
         assert authenticated_user is not None
         assert authenticated_user.username == "testuser"
 
@@ -112,70 +124,70 @@ class TestAuthService:
         """Test authentication with wrong password"""
         # Mock database session
         mock_db = AsyncMock()
-        
+
         # Mock user
         user = User(
             id=1,
             username="testuser",
             email="test@example.com",
             hashed_password=hash_password("test_pwd_123"),  # Shorter password
-            is_active=True
+            is_active=True,
         )
-        
+
         # Mock database query
         mock_result = AsyncMock()
         mock_result.scalar_one_or_none = Mock(return_value=user)  # Sync mock
         mock_db.execute = AsyncMock(return_value=mock_result)
-        
+
         # Test authentication with wrong password
         authenticated_user = await authenticate_user(mock_db, "testuser", "wrong_pwd")
-        
+
         assert authenticated_user is None
 
     async def test_authenticate_user_not_found(self):
         """Test authentication with non-existent user"""
         # Mock database session
         mock_db = AsyncMock()
-        
+
         # Mock database query returning None
         mock_result = AsyncMock()
         mock_result.scalar_one_or_none = Mock(return_value=None)  # Sync mock
         mock_db.execute = AsyncMock(return_value=mock_result)
-        
+
         # Test authentication
         authenticated_user = await authenticate_user(mock_db, "nonexistent", "pwd123")
-        
+
         assert authenticated_user is None
 
     async def test_get_current_user_success(self):
         """Test getting current user from valid token"""
         # Mock database session
         mock_db = AsyncMock()
-        
+
         # Mock user
         user = User(
             id=1,
             username="testuser",
             email="test@example.com",
             hashed_password="hashed",
-            is_active=True
+            is_active=True,
         )
-        
+
         # Mock database query
         mock_result = AsyncMock()
         mock_result.scalar_one_or_none = Mock(return_value=user)  # Sync mock
         mock_db.execute = AsyncMock(return_value=mock_result)
-        
+
         # Create token
         token = create_access_token({"sub": "testuser"})
-        
+
         # Mock credentials
         mock_credentials = Mock()
         mock_credentials.credentials = token
-        
+
         # Test get current user
         current_user = await get_current_user(mock_credentials, mock_db)
-        
+
         assert current_user is not None
         assert current_user.username == "testuser"
 
@@ -187,35 +199,82 @@ class TestUserCreation:
     async def test_create_user_password_hashing(self):
         """Test that passwords are properly hashed when creating users"""
         from services.user_service import create_user_service
-        
+
         # Mock database
         mock_db = AsyncMock()
-        
+
         # Mock no existing users
         mock_result = AsyncMock()
         mock_result.scalar_one_or_none.return_value = None
         mock_db.execute.return_value = mock_result
-        
+
         # Create user
         user_data = UserCreate(
             username="newuser",
             email="new@example.com",
             password="plain_pwd",  # Shorter password
-            is_active=True
+            is_active=True,
         )
-        
+
         # Mock add and commit
         mock_db.add = Mock()
         mock_db.commit = AsyncMock()
         mock_db.refresh = AsyncMock()
-        
+
         # This would normally create the user
         # We're testing that the password gets hashed
         hashed = hash_password("plain_pwd")
-        
+
         # Verify it's properly hashed
         assert hashed != "plain_pwd"
         assert verify_password("plain_pwd", hashed) is True
+
+
+class TestBcryptPasswordLimits:
+    """bcrypt 5 adaptation: explicit, controlled >72-byte password policy.
+
+    bcrypt only digests the first 72 bytes of a password. bcrypt 5 removed
+    the silent truncation, so the service must reject oversized passwords
+    with a domain error instead of letting a raw ValueError escape.
+    """
+
+    def test_hash_password_rejects_ascii_over_72_bytes(self):
+        """73 ASCII chars = 73 bytes -> PasswordTooLongError, not ValueError"""
+        with pytest.raises(PasswordTooLongError, match="72 bytes"):
+            hash_password("a" * 73)
+
+    def test_hash_password_rejects_multibyte_over_72_bytes(self):
+        """37 x 'ñ' is only 37 chars but 74 UTF-8 bytes -> rejected.
+
+        Proves the limit is enforced on encoded bytes, not characters.
+        """
+        with pytest.raises(PasswordTooLongError, match="72 bytes"):
+            hash_password("ñ" * 37)
+
+    def test_hash_password_accepts_exactly_72_bytes(self):
+        """Boundary: exactly 72 bytes must hash and verify normally"""
+        password = "a" * 72
+        hashed = hash_password(password)
+        assert hashed.startswith("$2b$")
+        assert verify_password(password, hashed) is True
+
+    def test_hash_password_accepts_multibyte_exactly_72_bytes(self):
+        """Boundary: 24 x '€' = 72 UTF-8 bytes must hash and verify"""
+        password = "€" * 24
+        hashed = hash_password(password)
+        assert verify_password(password, hashed) is True
+
+    def test_verify_password_over_72_bytes_returns_false(self):
+        """Login with an oversized password is an auth failure, not a crash"""
+        hashed = hash_password("short_pwd")
+        assert verify_password("a" * 73, hashed) is False
+
+    def test_verify_password_accepts_legacy_passlib_hash(self):
+        """Hashes stored by the passlib 1.7.4 + bcrypt 4 stack stay valid"""
+        assert verify_password("test_pwd_123", LEGACY_BCRYPT_HASH) is True
+
+    def test_verify_password_rejects_wrong_password_on_legacy_hash(self):
+        assert verify_password("wrong_pwd", LEGACY_BCRYPT_HASH) is False
 
 
 # Run tests


### PR DESCRIPTION
## Summary

Manual bcrypt 5 bump for the dashboard backend, with the auth adaptation that PR #156 was closed for (card fbe1e86d, item 1). The deny-list entry from #179 keeps Dependabot out; this is the dedicated manual path.

## Diagnosis (deeper than the #156 closing note)

bcrypt 5.0 removed the silent truncation of passwords >72 bytes. **passlib 1.7.4 is fundamentally incompatible with it**: during backend initialization passlib runs a `detect_wrap_bug` probe that deliberately hashes a >=72-byte secret relying on that truncation. With bcrypt 5 the probe raises `ValueError: password cannot be longer than 72 bytes` **at backend load**, so *every* `hash`/`verify` call fails — even for 12-byte passwords. This is why 8 auth tests went red in #156, not just long-password cases.

## Design decision: explicit rejection, no silent truncation

- `hash_password` encodes UTF-8 and enforces the **byte-level** limit (72 bytes, not chars — `'ñ' * 37` is 37 chars but 74 bytes) raising a domain exception `PasswordTooLongError(ValueError)`.
- `create_user_service` maps it to a controlled `400 Bad Request` (`Password too long: bcrypt accepts a maximum of 72 bytes`), following the existing username/email-conflict pattern.
- `verify_password` returns `False` for oversized candidates: no storable hash can match them (registration rejects), so login is a plain auth failure instead of a 500.
- passlib is dropped from the hashing path (unmaintained since 2020; only importer was `auth_service.py`) — direct `bcrypt` calls, same `b$`/12-round output format, so **existing stored hashes remain verifiable** (regression test with a legacy-format hash included).

## Changes

| File | Change |
|---|---|
| `dashboard/backend/services/auth_service.py` | passlib -> direct bcrypt; `PASSWORD_MAX_BYTES`, `PasswordTooLongError`, byte-level guard |
| `dashboard/backend/services/user_service.py` | `PasswordTooLongError` -> HTTP 400 at registration |
| `dashboard/backend/services/__init__.py` | export `PasswordTooLongError` |
| `dashboard/backend/requirements.txt` | `bcrypt==5.*`, `passlib[bcrypt]` removed |
| `tests/unit/test_auth_service.py` | `TestBcryptPasswordLimits`: ASCII/multibyte >72 rejection, 72-byte boundaries (ASCII + multibyte), verify-false path, legacy-hash compat |
| `tests/services/test_user_service.py` | registration rejects >72 bytes with 400, no DB write |

## Test evidence (TDD: RED -> GREEN)

- RED reproduced on main + bcrypt 5: 6 auth tests fail (passlib backend-init `ValueError`); raw `ValueError` escapes registration for >72-byte passwords.
- GREEN after adaptation: `tests/unit` + `tests/middleware` (CI gates) = **290 passed, 0 failed**; auth/user service tests incl. 8 new = green.
- Full-tree comparison vs main: fixes 9 failures, introduces 0 regressions (`tests/services` parallel/bulk/stripe failures are pre-existing on main with identical signature; 2 are proven flaky timing tests).
- `pip install --dry-run -r requirements.txt` resolves cleanly (no passlib/bcrypt conflict).

## Out of scope / follow-ups

- Removing `bcrypt` from the Dependabot deny-list (#179) once this lands — separate config PR.
- Pre-existing RED integration suite tracked in #110 (continue-on-error in CI, untouched).
- passlib NUL-byte rejection is not reimplemented: pyca/bcrypt hashes NUL-containing passwords deterministically with no truncation, so the historical passlib guard is unnecessary in this stack.

Refs #156, #179. Card fbe1e86d (item 1/5).