### PR TITLE
chore(deps): remove bcrypt from pip-backend-majors deny-list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,9 +71,6 @@ updates:
           - "fastapi"
           - "starlette"
           - "pydantic"
-          # bcrypt 5.x breaks passlib hashing for >72-byte secrets; PR #156
-          # closed until the auth adaptation lands (card fbe1e86d).
-          - "bcrypt"
       pip-backend-minors-patch:
         update-types:
           - "minor"


### PR DESCRIPTION
Follow-up post-merge de #197 (card fbe1e86d). El exclude temporal de `bcrypt` (añadido en #179 hasta la adaptación auth) quedó stale: con la adaptación bcrypt 5 mergeada, Dependabot vuelve a ofrecer majors de bcrypt. Quita 1 línea + comentario obsoleto.